### PR TITLE
Thread Safety Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,22 @@ jobs:
       - name: Run tests (release)
         if: matrix.configuration == 'release'
         run: swift test -c release -Xswiftc -enable-testing
+
+  tsan:
+    name: thread sanitizer (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: swift-actions/setup-swift@v2
+        if: runner.os == 'Linux'
+        with:
+          swift-version: "6.1"
+      - name: Show Swift version
+        run: swift --version
+      - name: Run concurrency tests under the thread sanitizer
+        run: swift test --sanitize=thread --filter Concurrency

--- a/.github/workflows/tsan-full.yml
+++ b/.github/workflows/tsan-full.yml
@@ -1,0 +1,28 @@
+name: Thread Sanitizer (full suite)
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  tsan-full:
+    name: full test suite under thread sanitizer (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: swift-actions/setup-swift@v2
+        if: runner.os == 'Linux'
+        with:
+          swift-version: "6.1"
+      - name: Show Swift version
+        run: swift --version
+      - name: Run all tests under the thread sanitizer
+        run: swift test --sanitize=thread
+      - name: Run the allocation tracing test under the thread sanitizer
+        run: swift test --sanitize=thread -Xswiftc -DDL4S_TRACE_ALLOCATIONS --filter ConcurrencyTests/testConcurrentAllocationTracing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,10 @@
 # AGENTS.md
-
 Guidance for coding agents that work in this repository.
 
 ## What this is
-
 DL4S is a pure Swift deep learning library with built-in reverse-mode automatic differentiation (dynamic compute graphs, no special toolchain). It provides tensor operations, NN layers, optimizers, losses, and reference architectures (ResNet18, VGG, AlexNet, Transformer). It supports macOS, iOS, tvOS, watchOS, and Linux. It has no external dependencies.
 
 ## Commands
-
 ```bash
 swift build                                          # build
 swift test                                           # run all tests
@@ -26,22 +23,17 @@ Tests are XCTest classes in `Tests/DL4STests`. The MNIST idx files in that direc
 `ConcurrencyTests` runs inference, dropout, and weight initialization from several raw threads at the same time. It is the acceptance test for the thread-safety work. Until the fixes land, the tests run as expected failures on Darwin and are skipped on Linux unless `DL4S_CONCURRENCY_TESTS=1` is set. Run the suite under the thread sanitizer to see the data races as reports.
 
 ## Architecture
-
 Two targets: `MKL` (a C shim that only exposes Intel MKL/IPP headers through `include/module.modulemap`; `placeholder.c` is empty on purpose) and `DL4S`, which depends on it. `Package.swift` sets no build flags; all acceleration configuration happens through command-line `-Xswiftc`/`-Xlinker` flags.
 
 ### Generic core: Tensor over Element and Device
-
 Everything is generic over two parameters: `Tensor<Element: NumericType, Device: DeviceType>` (`Sources/DL4S/Tensor/Tensor.swift`). Valid elements are `Float`, `Double`, and `Int32` (`Sources/DL4S/Numerics/`).
-
 - `DeviceType` (`Sources/DL4S/Engine/Engine.swift`) bundles two associated types: `Memory: MemoryOperatorsType` (raw allocation, slicing) and `Engine: EngineType` (the full kernel catalogue: broadcast ops, gemm, conv, reductions, scatter/gather, etc.).
 - `CPU` (`Engine/CPU/`) is the only device. `CPUEngine` methods are thin shims that forward to static methods on the element type (`CPUNumeric` protocol). The per-type implementations in `Engine/CPU/Numeric/` select between three variants with conditional compilation: `#if MKL_ENABLE`, `#elseif canImport(Accelerate)`, and a generic Swift fallback (`CPUGeneric.swift`). A GPU backend can conform to the same protocols, but none exists.
 - Kernels that accumulate into an existing gradient have fused `...Add` variants (`permuteAxesAdd`, `subscriptWriteAdd`, `reverseAdd`, ...). Backward passes use these to avoid a separate add kernel.
 - `Tensor` wraps a `TensorHandle` class with copy-on-write (`ensureOwnership()`); views share the parent buffer, and only the root handle frees it.
 
 ### Automatic differentiation
-
 Autograd is closure-based and lives in `Sources/DL4S/Tensor/`:
-
 - Each differentiable operation (all in `Tensor/Operators/*.swift`) computes its forward result through the engine, then attaches a `TensorContext` (`Context.swift`) that holds the source tensors and one backpropagation closure per source. Capture only happens when an operand `requiresGradient`.
 - `tensor.gradients(of:retainBackwardsGraph:)` (`Tensor.swift`) topologically sorts the graph by `backpropID` and walks it backwards. Backward closures are written with normal tensor operations, so the backward pass builds its own graph when `retainBackwardsGraph: true`, which enables second and higher derivatives. With `false`, accumulated gradients are detached.
 - New tensor operation checklist: add the primitive to `EngineType`, implement it in `CPUEngine` (usually delegating to a `CPUNumeric` static, implemented in `CPUFloat`/`CPUDouble`/`CPUInt32`/`CPUGeneric`), then add the public `Tensor` method in the matching `Tensor/Operators/*.swift` file with its `TensorContext` gradient closures. Add a gradient check to `Tests/DL4STests/GradientTests.swift` and tick the README feature list.
@@ -49,21 +41,18 @@ Autograd is closure-based and lives in `Sources/DL4S/Tensor/`:
 - Debug-only graph tooling: `Tensor.tag`, `OperationGroup.capture(named:)`, and `tensor.graph()` (Graphviz DOT output) are gated behind `#if DEBUG`.
 
 ### NN layer system
-
 - `LayerType` (`NN/Layer/Layer.swift`) has associated `Inputs`/`Outputs` types (not fixed to tensors, which is how RNNs return tuples), `callAsFunction`, and two parameter accessors: `parameters` and `parameterPaths` (writable key paths into the layer struct).
 - Layers are value types. Optimizers (`NN/Optimizer/`) copy the model and mutate its parameters through `parameterPaths`. This is why usage code must call `optimizer.model(input)`, never the original `model` variable.
 - `Sequential` (`NN/Layer/Sequential.swift`) is a result builder that folds a block of layers into nested `Sequential<Sequential<A, B>, C>` pairs.
 - Reference architectures live in `NN/Models/`.
 
 ## Conventions
-
 - Every file starts with the MIT license header (`// <Filename>.swift / DL4S / Created by ... / Copyright ...`). New files get the same header.
 - Public APIs carry `///` doc comments with `- Parameters:` / `- Returns:`. The `docs/` directory is Jazzy output; do not hand-edit it.
 - Hot generic functions use `@inline(__always)` and `@_specialize(where Element == Float, Device == CPU)`.
 - Engine primitives use terse names (`vAdd`, `vsMul`, `gemm`, `img2col`); public tensor methods are spelled out (`matrixMultiplied(with:)`, `permuted(to:)`, `reduceSum(along:)`).
 
 ## Debugging
-
 `util/debugger_support/tensor.py` is an LLDB script that adds readable summaries for `Tensor` and `ShapedBuffer` values. Load it with `command script import` in LLDB or from `~/.lldbinit`.
 
 ## Documentation & Communication

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,4 @@ Autograd is closure-based and lives in `Sources/DL4S/Tensor/`:
 - Avoid em-dashes and en-dashes in sentence constructions. Write concisely. 
 - Phrases to avoid: "load-bearing", "gated", "the X is real", "X is doing a lot of work", "it's not X, it's Y", "genuinely", "{Ticket}/{fix} lands" / "{fix} has landed"
 - Do not include ticket IDs or phases in any code, including unit tests.
+- Avoid mannered prose: writing that uses metaphor or a striking phrase where a plain statement would do. Examples: "a dial worth turning" for "a parameter worth varying"; "this point earns its keep" for "this point still matters." Such phrases draw attention to the writing rather than the idea, and they are less precise, because a metaphor carries associations the writer did not intend. When a literal phrase is available, use it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,11 @@ There is no linter or formatter configuration in this repo. CI is a GitHub Actio
 
 On Linux, acceleration comes from Intel MKL/IPP instead of Accelerate. Build with `swift build -c release -Xswiftc -DMKL_ENABLE -Xlinker -L${MKLROOT}/lib/intel64 -Xlinker -L${IPPROOT}/lib/intel64` (see README for setup). Without MKL or Accelerate, a slow generic fallback is used.
 
+Allocation tracing is a debugging aid that is compiled in only with `-Xswiftc -DDL4S_TRACE_ALLOCATIONS`. With the flag, `CPUMemoryOperators.setAllocationTracing(true)` records the call stack of every allocation and prints the call stack of a buffer that is not freed after 5 seconds. Builds without the flag contain no tracing code. Run the tracing test with `swift test --sanitize=thread -Xswiftc -DDL4S_TRACE_ALLOCATIONS --filter Concurrency`.
+
 Tests are XCTest classes in `Tests/DL4STests`. The MNIST idx files in that directory are bundled as test resources. Tests that train real models (`MNISTTests`, `TransformerTests`, `ModelTests`) or measure performance are slow and are skipped unless the `DL4S_LONG_TESTS` environment variable is set, so CI does not run them. Run them locally with `DL4S_LONG_TESTS=1 swift test`.
 
-`ConcurrencyTests` runs inference, dropout, and weight initialization from several raw threads at the same time. It is the acceptance test for the thread-safety work. Until the fixes land, the tests run as expected failures on Darwin and are skipped on Linux unless `DL4S_CONCURRENCY_TESTS=1` is set. Run the suite under the thread sanitizer to see the data races as reports.
+`ConcurrencyTests` runs inference, backpropagation, dropout, and weight initialization from several raw threads at the same time. It is the acceptance test for the thread-safety work. Run the suite under the thread sanitizer to see data races as reports.
 
 ## Architecture
 Two targets: `MKL` (a C shim that only exposes Intel MKL/IPP headers through `include/module.modulemap`; `placeholder.c` is empty on purpose) and `DL4S`, which depends on it. `Package.swift` sets no build flags; all acceleration configuration happens through command-line `-Xswiftc`/`-Xlinker` flags.
@@ -34,11 +36,12 @@ Everything is generic over two parameters: `Tensor<Element: NumericType, Device:
 
 ### Automatic differentiation
 Autograd is closure-based and lives in `Sources/DL4S/Tensor/`:
-- Each differentiable operation (all in `Tensor/Operators/*.swift`) computes its forward result through the engine, then attaches a `TensorContext` (`Context.swift`) that holds the source tensors and one backpropagation closure per source. Capture only happens when an operand `requiresGradient`.
+- Each differentiable operation (all in `Tensor/Operators/*.swift`) computes its forward result through the engine, then attaches a `TensorContext` (`Context.swift`) that holds the source tensors and the backpropagation closures. The context has two forms: one closure per source (the default), or one closure for all sources (`backpropagateAll:`) that owns the accumulators and returns every source gradient at once. Use the second form when one kernel produces all source gradients, as `stack` does, so the kernel runs once per backward visit and the closures share no state. Capture only happens when an operand `requiresGradient`.
 - `tensor.gradients(of:retainBackwardsGraph:)` (`Tensor.swift`) topologically sorts the graph by `backpropID` and walks it backwards. Backward closures are written with normal tensor operations, so the backward pass builds its own graph when `retainBackwardsGraph: true`, which enables second and higher derivatives. With `false`, accumulated gradients are detached.
 - New tensor operation checklist: add the primitive to `EngineType`, implement it in `CPUEngine` (usually delegating to a `CPUNumeric` static, implemented in `CPUFloat`/`CPUDouble`/`CPUInt32`/`CPUGeneric`), then add the public `Tensor` method in the matching `Tensor/Operators/*.swift` file with its `TensorContext` gradient closures. Add a gradient check to `Tests/DL4STests/GradientTests.swift` and tick the README feature list.
 - Backward closures must not capture the result tensor directly (retain cycle). See `exp`/`tanh` in `Unary.swift`: they capture a copy and recompute the forward value when the backward graph itself needs gradients.
-- Debug-only graph tooling: `Tensor.tag`, `OperationGroup.capture(named:)`, and `tensor.graph()` (Graphviz DOT output) are gated behind `#if DEBUG`.
+- Debug-only graph tooling: `Tensor.tag`, `OperationGroup.capture(named:)`, and `tensor.graph()` (Graphviz DOT output) are compiled only in `#if DEBUG`. The operation stack that `capture` records is a `@TaskLocal`, so each thread or task has its own stack.
+- Each tensor gets its `backpropID` from a process-wide atomic counter (`UniqueID`). Copies keep the id. `ensureOwnership` creates a new tensor with a new id when the buffer is shared.
 
 ### NN layer system
 - `LayerType` (`NN/Layer/Layer.swift`) has associated `Inputs`/`Outputs` types (not fixed to tensors, which is how RNNs return tuples), `callAsFunction`, and two parameter accessors: `parameters` and `parameterPaths` (writable key paths into the layer struct).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ swift test --filter Concurrency                      # run the thread-safety str
 swift test --sanitize=thread --filter Concurrency    # run it under the thread sanitizer
 ```
 
-There is no linter or formatter configuration in this repo. CI is a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs `swift test` in debug and release configuration (`-c release -Xswiftc -enable-testing`) on macOS and Ubuntu.
+There is no linter or formatter configuration in this repo. CI is a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs `swift test` in debug and release configuration (`-c release -Xswiftc -enable-testing`) on macOS and Ubuntu, and runs the concurrency suite under the thread sanitizer. A second workflow (`.github/workflows/tsan-full.yml`) runs the full test suite under the thread sanitizer on every push to master and on manual dispatch.
 
 On Linux, acceleration comes from Intel MKL/IPP instead of Accelerate. Build with `swift build -c release -Xswiftc -DMKL_ENABLE -Xlinker -L${MKLROOT}/lib/intel64 -Xlinker -L${IPPROOT}/lib/intel64` (see README for setup). Without MKL or Accelerate, a slow generic fallback is used.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ swift build                                          # build
 swift test                                           # run all tests
 swift test --filter DL4STests.GradientTests          # run one test class
 swift test --filter DL4STests.GradientTests/testMul  # run one test method
-swift test --generate-linuxmain                      # regenerate XCTestManifests.swift after adding tests
+swift test --filter Concurrency                      # run the thread-safety stress suite
+swift test --sanitize=thread --filter Concurrency    # run it under the thread sanitizer
 ```
 
 There is no linter or formatter configuration in this repo. CI is a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs `swift test` in debug and release configuration (`-c release -Xswiftc -enable-testing`) on macOS and Ubuntu.
@@ -21,6 +22,8 @@ There is no linter or formatter configuration in this repo. CI is a GitHub Actio
 On Linux, acceleration comes from Intel MKL/IPP instead of Accelerate. Build with `swift build -c release -Xswiftc -DMKL_ENABLE -Xlinker -L${MKLROOT}/lib/intel64 -Xlinker -L${IPPROOT}/lib/intel64` (see README for setup). Without MKL or Accelerate, a slow generic fallback is used.
 
 Tests are XCTest classes in `Tests/DL4STests`. The MNIST idx files in that directory are bundled as test resources. Tests that train real models (`MNISTTests`, `TransformerTests`, `ModelTests`) or measure performance are slow and are skipped unless the `DL4S_LONG_TESTS` environment variable is set, so CI does not run them. Run them locally with `DL4S_LONG_TESTS=1 swift test`.
+
+`ConcurrencyTests` runs inference, dropout, and weight initialization from several raw threads at the same time. It is the acceptance test for the thread-safety work. Until the fixes land, the tests run as expected failures on Darwin and are skipped on Linux unless `DL4S_CONCURRENCY_TESTS=1` is set. Run the suite under the thread sanitizer to see the data races as reports.
 
 ## Architecture
 
@@ -67,4 +70,5 @@ Autograd is closure-based and lives in `Sources/DL4S/Tensor/`:
 - All communication, comments, documentation, etc. must use ASD-STE100 Simple Technical English.
 - Documentation must follow the Google Developer Documentation style guide. This includes spelling, terminology, choice of words, inclusive language, phrasing and  sentence construction.
 - Avoid em-dashes and en-dashes in sentence constructions. Write concisely. 
-- Phrases to avoid: "load-bearing", "gated", "the X is real", "X is doing a lot of work", "it's not X, it's Y", "genuinely"
+- Phrases to avoid: "load-bearing", "gated", "the X is real", "X is doing a lot of work", "it's not X, it's Y", "genuinely", "{Ticket}/{fix} lands" / "{fix} has landed"
+- Do not include ticket IDs or phases in any code, including unit tests.

--- a/Sources/DL4S/Engine/Buffer.swift
+++ b/Sources/DL4S/Engine/Buffer.swift
@@ -26,25 +26,57 @@
 import Foundation
 
 
-/// A buffer that holds a region of memory with a given length
+/// A read-only view of a region of device memory with a given length.
 public struct Buffer<Element, Device: DeviceType> {
     let memory: Device.Memory.RawBuffer
+    
+    init(memory: Device.Memory.RawBuffer) {
+        self.memory = memory
+    }
+    
+    init(_ buffer: MutableBuffer<Element, Device>) {
+        self.memory = buffer.memory
+    }
     
     var count: Int {
         return Device.Memory.getSize(of: self)
     }
     
     var pointee: Element {
+        return Device.Memory.getValue(from: self)
+    }
+    
+    func advanced(by offset: Int) -> Buffer<Element, Device> {
+        return Device.Memory.advance(buffer: self, by: offset)
+    }
+    
+    subscript(index: Int) -> Element {
+        return advanced(by: index).pointee
+    }
+}
+
+/// A writable region of device memory with a given length.
+public struct MutableBuffer<Element, Device: DeviceType> {
+    let memory: Device.Memory.RawBuffer
+    
+    init(memory: Device.Memory.RawBuffer) {
+        self.memory = memory
+    }
+    
+    var count: Int {
+        return Buffer(self).count
+    }
+    
+    var pointee: Element {
         get {
-            return Device.Memory.getValue(from: self)
+            return Buffer(self).pointee
         }
-        
         nonmutating set (newValue) {
             Device.Memory.setPointee(of: self, to: newValue)
         }
     }
     
-    func advanced(by offset: Int) -> Buffer<Element, Device> {
+    func advanced(by offset: Int) -> MutableBuffer<Element, Device> {
         return Device.Memory.advance(buffer: self, by: offset)
     }
     
@@ -71,17 +103,11 @@ extension Buffer {
 
 extension Buffer: CustomLeafReflectable {
     public var customMirror: Mirror {
-        let b = UnsafeMutableBufferPointer<Element>.allocate(capacity: self.count)
-        defer {
-            b.deallocate()
-        }
-        Device.Memory.assign(from: self, to: b, count: self.count)
-        let a = Array(b)
-        return Mirror(self, unlabeledChildren: a, displayStyle: .collection)
+        return Mirror(self, unlabeledChildren: array, displayStyle: .collection)
     }
 }
 
-/// A buffer that holds a region of memory with a given shape
+/// A read-only view of a region of device memory with a given shape.
 public struct ShapedBuffer<Element, Device: DeviceType> {
     var shape: [Int]
     var values: Buffer<Element, Device>
@@ -99,10 +125,61 @@ public struct ShapedBuffer<Element, Device: DeviceType> {
         self.values = values
     }
     
+    init(_ buffer: MutableShapedBuffer<Element, Device>) {
+        self.shape = buffer.shape
+        self.values = Buffer(buffer.values)
+    }
+    
     func reshaped(to shape: [Int]) -> ShapedBuffer<Element, Device> {
         precondition(shape.reduce(1, *) == self.shape.reduce(1, *))
         
         return ShapedBuffer(values: values, shape: shape)
+    }
+}
+
+/// A writable region of device memory with a given shape.
+public struct MutableShapedBuffer<Element, Device: DeviceType> {
+    let shape: [Int]
+    let values: MutableBuffer<Element, Device>
+    
+    var dim: Int {
+        return shape.count
+    }
+    
+    var count: Int {
+        return values.count
+    }
+    
+    fileprivate init(values: MutableBuffer<Element, Device>, shape: [Int]) {
+        self.shape = shape
+        self.values = values
+    }
+}
+
+public extension MemoryOperatorsType {
+    /// Allocates a buffer with capacity for the amount of elements in the given shape
+    /// - Parameters:
+    ///   - shape: Shape of the buffer to allocate
+    ///   - type: Type of elements in the buffer
+    static func allocateBuffer<Element>(withShape shape: [Int], type: Element.Type) -> MutableShapedBuffer<Element, Device> {
+        return MutableShapedBuffer(values: allocateBuffer(withCapacity: shape.reduce(1, *), type: type), shape: shape)
+    }
+    
+    /// Releases all resources associated with the given buffer
+    /// - Parameter buffer: Buffer to release
+    static func free<Element>(_ buffer: MutableShapedBuffer<Element, Device>) {
+        free(buffer.values)
+    }
+}
+
+extension Tensor {
+    /// Writable storage of the tensor.
+    var mutableValues: MutableShapedBuffer<Element, Device> {
+        mutating get {
+            // Assume write, so perform CoW if necessary.
+            ensureOwnership()
+            return MutableShapedBuffer(values: handle.values, shape: shape)
+        }
     }
 }
 

--- a/Sources/DL4S/Engine/CPU/CPU.swift
+++ b/Sources/DL4S/Engine/CPU/CPU.swift
@@ -106,9 +106,7 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
             allocations.removeValue(forKey: buffer.memory.baseAddress!)
             sema.signal()
         }
-        DispatchQueue.global().async {
-            buffer.memory.deallocate()
-        }
+        buffer.memory.deallocate()
     }
     
     public static func free<Element>(_ buffer: ShapedBuffer<Element, CPU>) {

--- a/Sources/DL4S/Engine/CPU/CPU.swift
+++ b/Sources/DL4S/Engine/CPU/CPU.swift
@@ -68,7 +68,7 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
         return zip(shape, strides).map { dim, str in (linearIndex / str) % dim}
     }
     
-    public static func allocateBuffer<Element>(withCapacity capacity: Int, type: Element.Type) -> Buffer<Element, CPU> {
+    public static func allocateBuffer<Element>(withCapacity capacity: Int, type: Element.Type) -> MutableBuffer<Element, CPU> {
         let stride = MemoryLayout<Element>.stride
         let alignment = max(MemoryLayout<Element>.alignment, 16)
         
@@ -92,15 +92,10 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
             }
         }
         
-        return Buffer<Element, CPU>(memory: buffer)
+        return MutableBuffer<Element, CPU>(memory: buffer)
     }
     
-    public static func allocateBuffer<Element>(withShape shape: [Int], type: Element.Type) -> ShapedBuffer<Element, CPU> {
-        let count = shape.reduce(1, *)
-        return ShapedBuffer(values: allocateBuffer(withCapacity: count, type: Element.self), shape: shape)
-    }
-    
-    public static func free<Element>(_ buffer: Buffer<Element, CPU>) {
+    public static func free<Element>(_ buffer: MutableBuffer<Element, CPU>) {
         if traceAllocations {
             sema.wait()
             allocations.removeValue(forKey: buffer.memory.baseAddress!)
@@ -109,16 +104,12 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
         buffer.memory.deallocate()
     }
     
-    public static func free<Element>(_ buffer: ShapedBuffer<Element, CPU>) {
-        free(buffer.values)
-    }
-    
-    public static func assign<Element>(from source: UnsafeBufferPointer<Element>, to destination: Buffer<Element, CPU>, count: Int) {
+    public static func assign<Element>(from source: UnsafeBufferPointer<Element>, to destination: MutableBuffer<Element, CPU>, count: Int) {
         // destination.memory.bindMemory(to: Element.self).assign(from: source, count: count)
         memcpy(destination.memory.baseAddress!, source.baseAddress!, count * MemoryLayout<Element>.stride)
     }
     
-    public static func assign<Element>(from source: Buffer<Element, CPU>, to destination: Buffer<Element, CPU>, count: Int) {
+    public static func assign<Element>(from source: Buffer<Element, CPU>, to destination: MutableBuffer<Element, CPU>, count: Int) {
         // destination.memory.bindMemory(to: Element.self).assign(from: source.memory.bindMemory(to: Element.self).immutable, count: count)
         memcpy(destination.memory.baseAddress!, source.memory.baseAddress!, count * MemoryLayout<Element>.stride)
     }
@@ -132,7 +123,7 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
     @_specialize(where Element == Float)
     @_specialize(where Element == Int32)
     @_specialize(where Element == Double)
-    public static func get<Element>(slice: [Int?], of buffer: Buffer<Element, CPU>, with shape: [Int]) -> (Buffer<Element, CPU>, Bool, [Int]) {
+    public static func get<Element>(slice: [Int?], of buffer: Buffer<Element, CPU>, with shape: [Int]) -> (MutableBuffer<Element, CPU>, Bool, [Int]) {
         precondition(slice.count <= shape.count, "Index must be smaller than or equal to vector size")
         
         // Prevent unneccessary copies when index ends with nil
@@ -152,7 +143,7 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
                 rebasing: bound.advanced(by: offset).prefix(resultShape.reduce(1, *))
             )
             let advancedRaw = UnsafeMutableRawBufferPointer(advanced)
-            return (Buffer<Element, CPU>(memory: advancedRaw), false, resultShape)
+            return (MutableBuffer<Element, CPU>(memory: advancedRaw), false, resultShape)
         } else {
             let padded = slice + [Int?](repeating: nil, count: shape.count - slice.count)
             
@@ -171,7 +162,7 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
         }
     }
     
-    public static func get<Element>(slice: [(CountableRange<Int>)?], of buffer: Buffer<Element, CPU>, with shape: [Int]) -> (Buffer<Element, CPU>, Bool, [Int]) {
+    public static func get<Element>(slice: [(CountableRange<Int>)?], of buffer: Buffer<Element, CPU>, with shape: [Int]) -> (MutableBuffer<Element, CPU>, Bool, [Int]) {
         precondition(slice.count <= shape.count, "Index must be smaller than or equal to vector size")
         
         let strides = CPUMemoryOperators.strides(from: shape)
@@ -191,7 +182,7 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
         return (resultBuffer, true, resultShape)
     }
     
-    public static func set<Element>(slice: [Int?], of buffer: Buffer<Element, CPU>, with dstShape: [Int], from source: Buffer<Element, CPU>, with sourceShape: [Int]) {
+    public static func set<Element>(slice: [Int?], of buffer: MutableBuffer<Element, CPU>, with dstShape: [Int], from source: Buffer<Element, CPU>, with sourceShape: [Int]) {
         let countDelta = dstShape.count - slice.filter {$0 != nil}.count
         precondition(sourceShape.count == countDelta, "Dimensionality of source must be equal to dimensionality of destination minus number of knowns in slice")
         
@@ -201,7 +192,7 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
         iterativeWrite(source: source.memory.bindMemory(to: Element.self).immutable, destination: buffer.memory.bindMemory(to: Element.self), dstIndex: padded, dstStrides: dstStrides, dstShape: dstShape)
     }
     
-    public static func set<Element>(slice: [Range<Int>?], of buffer: Buffer<Element, CPU>, with dstShape: [Int], from source: Buffer<Element, CPU>, with sourceShape: [Int]) {
+    public static func set<Element>(slice: [Range<Int>?], of buffer: MutableBuffer<Element, CPU>, with dstShape: [Int], from source: Buffer<Element, CPU>, with sourceShape: [Int]) {
         precondition(sourceShape.count == dstShape.count, "Dimensionality of source must be equal to dimensionality of destination")
         
         let padded = slice + [Range<Int>?](repeating: nil, count: dstShape.count - slice.count)
@@ -219,16 +210,22 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
     }
     
     public static func advance<Element>(buffer: Buffer<Element, CPU>, by advancement: Int) -> Buffer<Element, CPU> {
-        return Buffer<Element, CPU>(
-            memory: UnsafeMutableRawBufferPointer(
-                buffer.memory
-                    .bindMemory(to: Element.self)
-                    .advanced(by: advancement)
-            )
+        return Buffer<Element, CPU>(memory: advance(memory: buffer.memory, by: advancement, type: Element.self))
+    }
+    
+    public static func advance<Element>(buffer: MutableBuffer<Element, CPU>, by advancement: Int) -> MutableBuffer<Element, CPU> {
+        return MutableBuffer<Element, CPU>(memory: advance(memory: buffer.memory, by: advancement, type: Element.self))
+    }
+    
+    private static func advance<Element>(memory: UnsafeMutableRawBufferPointer, by advancement: Int, type: Element.Type) -> UnsafeMutableRawBufferPointer {
+        return UnsafeMutableRawBufferPointer(
+            memory
+                .bindMemory(to: Element.self)
+                .advanced(by: advancement)
         )
     }
     
-    public static func setPointee<Element>(of buffer: Buffer<Element, CPU>, to newValue: Element) {
+    public static func setPointee<Element>(of buffer: MutableBuffer<Element, CPU>, to newValue: Element) {
         buffer.pointer.pointee = newValue
     }
 }

--- a/Sources/DL4S/Engine/CPU/CPU.swift
+++ b/Sources/DL4S/Engine/CPU/CPU.swift
@@ -24,6 +24,9 @@
 //  SOFTWARE.
 
 import Foundation
+#if DL4S_TRACE_ALLOCATIONS
+import Synchronization
+#endif
 
 
 public struct CPU: DeviceType {
@@ -34,14 +37,6 @@ public struct CPU: DeviceType {
 public struct CPUMemoryOperators: MemoryOperatorsType {
     public typealias RawBuffer = UnsafeMutableRawBufferPointer
     public typealias Device = CPU
-    
-    static var traceAllocations: Bool = false {
-        didSet {
-            allocations.removeAll()
-        }
-    }
-    private static var allocations: [UnsafeMutableRawPointer: [String]] = [:]
-    private static let sema = DispatchSemaphore(value: 1)
     
     @inline(__always)
     static func strides(from shape: [Int]) -> [Int] {
@@ -73,34 +68,16 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
         let alignment = max(MemoryLayout<Element>.alignment, 16)
         
         let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: stride * capacity, alignment: alignment)
-        
-        if traceAllocations {
-            sema.wait()
-            let trace = Thread.callStackSymbols
-            allocations[buffer.baseAddress!] = trace
-            sema.signal()
-
-            DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(5)) {
-                sema.wait()
-                if let trace = allocations[buffer.baseAddress!] {
-                    print("[ALLOC TRACE]: buffer of size \(capacity) not freed after 3 seconds.")
-                    print("[ALLOC TRACE] [begin callstack]")
-                    print(trace.joined(separator: "\n"))
-                    print("[ALLOC TRACE] [end callstack]")
-                }
-                sema.signal()
-            }
-        }
-        
+        #if DL4S_TRACE_ALLOCATIONS
+        recordAllocation(of: buffer, capacity: capacity)
+        #endif
         return MutableBuffer<Element, CPU>(memory: buffer)
     }
     
     public static func free<Element>(_ buffer: MutableBuffer<Element, CPU>) {
-        if traceAllocations {
-            sema.wait()
-            allocations.removeValue(forKey: buffer.memory.baseAddress!)
-            sema.signal()
-        }
+        #if DL4S_TRACE_ALLOCATIONS
+        recordFree(of: buffer.memory)
+        #endif
         buffer.memory.deallocate()
     }
     
@@ -229,3 +206,75 @@ public struct CPUMemoryOperators: MemoryOperatorsType {
         buffer.pointer.pointee = newValue
     }
 }
+
+#if DL4S_TRACE_ALLOCATIONS
+// MARK: Allocation tracing
+//
+// Compile with `-Xswiftc -DDL4S_TRACE_ALLOCATIONS` to enable this feature.
+
+struct AllocationTraceState: Sendable {
+    /// Whether allocate and free record call stacks.
+    var isEnabled = false
+    
+    /// Call stacks of live allocations, by the address of the buffer.
+    var callStacks: [UInt: [String]] = [:]
+}
+
+public extension CPUMemoryOperators {
+    /// Time in seconds after which a live allocation is reported as a possible leak.
+    static let allocationTraceReportDelaySeconds = 5
+    
+    internal static let allocationTraceState = Mutex(AllocationTraceState())
+    
+    /// Switches allocation tracing on or off.
+    ///
+    /// While tracing is on, every allocation records its call stack. A buffer that is not freed within
+    /// `allocationTraceReportDelaySeconds` is printed with the call stack of its allocation.
+    /// Switching tracing on or off discards the recorded call stacks.
+    ///
+    /// - Parameter enabled: Whether to trace allocations.
+    static func setAllocationTracing(_ enabled: Bool) {
+        allocationTraceState.withLock { state in
+            state.isEnabled = enabled
+            state.callStacks.removeAll()
+        }
+    }
+    
+    /// Number of allocations that are traced and not yet freed.
+    static var tracedAllocationCount: Int {
+        allocationTraceState.withLock { $0.callStacks.count }
+    }
+    
+    internal static func recordAllocation(of buffer: UnsafeMutableRawBufferPointer, capacity: Int) {
+        let address = UInt(bitPattern: buffer.baseAddress!)
+        let isEnabled = allocationTraceState.withLock { state in
+            guard state.isEnabled else {
+                return false
+            }
+            state.callStacks[address] = Thread.callStackSymbols
+            return true
+        }
+        guard isEnabled else {
+            return
+        }
+        
+        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(allocationTraceReportDelaySeconds)) {
+            let callStack = allocationTraceState.withLock { $0.callStacks[address] }
+            guard let callStack else {
+                return
+            }
+            print("[ALLOC TRACE]: buffer of size \(capacity) not freed after \(allocationTraceReportDelaySeconds) seconds.")
+            print("[ALLOC TRACE] [begin callstack]")
+            print(callStack.joined(separator: "\n"))
+            print("[ALLOC TRACE] [end callstack]")
+        }
+    }
+    
+    internal static func recordFree(of buffer: UnsafeMutableRawBufferPointer) {
+        let address = UInt(bitPattern: buffer.baseAddress!)
+        allocationTraceState.withLock { state in
+            _ = state.callStacks.removeValue(forKey: address)
+        }
+    }
+}
+#endif

--- a/Sources/DL4S/Engine/CPU/CPUEngine.swift
+++ b/Sources/DL4S/Engine/CPU/CPUEngine.swift
@@ -27,6 +27,12 @@ import Foundation
 
 
 extension ShapedBuffer where Device == CPU {
+    var immutable: UnsafeBufferPointer<Element> {
+        return values.memory.bindMemory(to: Element.self).immutable
+    }
+}
+
+extension MutableShapedBuffer where Device == CPU {
     var pointer: UnsafeMutableBufferPointer<Element> {
         return values.memory.bindMemory(to: Element.self)
     }
@@ -37,6 +43,12 @@ extension ShapedBuffer where Device == CPU {
 }
 
 extension Buffer where Device == CPU {
+    var immutable: UnsafeBufferPointer<Element> {
+        return memory.bindMemory(to: Element.self).immutable
+    }
+}
+
+extension MutableBuffer where Device == CPU {
     var pointer: UnsafeMutableBufferPointer<Element> {
         return memory.bindMemory(to: Element.self)
     }
@@ -57,27 +69,27 @@ private enum BroadcastMode: Int {
 public struct CPUEngine: EngineType {
     public typealias Device = CPU
     
-    public static func fill<N: NumericType>(value: N, result: Buffer<N, Device>, count: Int) {
+    public static func fill<N: NumericType>(value: N, result: MutableBuffer<N, Device>, count: Int) {
         N.fill(value: value, result: result.memory.bindMemory(to: N.self), count: count)
     }
     
-    public static func vAdd<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: Buffer<N, Device>, count: Int) {
+    public static func vAdd<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: MutableBuffer<N, Device>, count: Int) {
         N.vAdd(lhs: lhs.memory.bindMemory(to: N.self).immutable, rhs: rhs.memory.bindMemory(to: N.self).immutable, result: result.memory.bindMemory(to: N.self), count: count)
     }
     
-    public static func vNeg<N: NumericType>(val: Buffer<N, Device>, result: Buffer<N, Device>, count: Int) {
+    public static func vNeg<N: NumericType>(val: Buffer<N, Device>, result: MutableBuffer<N, Device>, count: Int) {
         N.vNeg(val: val.memory.bindMemory(to: N.self).immutable, result: result.memory.bindMemory(to: N.self), count: count)
     }
     
-    public static func vSub<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: Buffer<N, Device>, count: Int) {
+    public static func vSub<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: MutableBuffer<N, Device>, count: Int) {
         N.vSub(lhs: lhs.memory.bindMemory(to: N.self).immutable, rhs: rhs.memory.bindMemory(to: N.self).immutable, result: result.memory.bindMemory(to: N.self), count: count)
     }
     
-    public static func vMul<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: Buffer<N, Device>, count: Int) {
+    public static func vMul<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: MutableBuffer<N, Device>, count: Int) {
         N.vMul(lhs: lhs.memory.bindMemory(to: N.self).immutable, rhs: rhs.memory.bindMemory(to: N.self).immutable, result: result.memory.bindMemory(to: N.self), count: count)
     }
     
-    public static func vDiv<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: Buffer<N, Device>, count: Int) {
+    public static func vDiv<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: MutableBuffer<N, Device>, count: Int) {
         N.vDiv(lhs: lhs.memory.bindMemory(to: N.self).immutable, rhs: rhs.memory.bindMemory(to: N.self).immutable, result: result.memory.bindMemory(to: N.self), count: count)
     }
     
@@ -90,7 +102,7 @@ public struct CPUEngine: EngineType {
     private static func broadcast<N>(
         lhs: ShapedBuffer<N, CPU>,
         rhs: ShapedBuffer<N, CPU>,
-        result: ShapedBuffer<N, CPU>,
+        result: MutableShapedBuffer<N, CPU>,
         operator: (UnsafeBufferPointer<N>, UnsafeBufferPointer<N>, UnsafeMutableBufferPointer<N>, Int) -> (),
         scalarOperatorA: (N, UnsafeBufferPointer<N>, UnsafeMutableBufferPointer<N>, Int) -> (),
         scalarOperatorB: (UnsafeBufferPointer<N>, N, UnsafeMutableBufferPointer<N>, Int) -> ()
@@ -217,7 +229,7 @@ public struct CPUEngine: EngineType {
     @_specialize(where N == Float)
     private static func reduce<N>(
         values: ShapedBuffer<N, CPU>,
-        result: ShapedBuffer<N, CPU>,
+        result: MutableShapedBuffer<N, CPU>,
         axis: Int,
         reduceOperator: (_ buffer: UnsafeBufferPointer<N>, _  stride: Int, _ count: Int) -> N
     ) {
@@ -266,7 +278,7 @@ public struct CPUEngine: EngineType {
     @_specialize(where N == Float)
     private static func reduceMultiAxis<N>(
         values: ShapedBuffer<N, CPU>,
-        result: ShapedBuffer<N, CPU>,
+        result: MutableShapedBuffer<N, CPU>,
         axes: [Int],
         reduceOperator: (UnsafeBufferPointer<N>, Int) -> N
     ) {
@@ -305,7 +317,7 @@ public struct CPUEngine: EngineType {
     @_specialize(where N == Float)
     private static func reduceMultiAxis<N: ZeroableType>(
         values: ShapedBuffer<N, CPU>,
-        result: ShapedBuffer<N, CPU>,
+        result: MutableShapedBuffer<N, CPU>,
         axes: [Int],
         reduceOperator: (_ buffer: UnsafeBufferPointer<N>, _  stride: Int, _ count: Int) -> N,
         reduceCombine: (N, N) -> N
@@ -381,7 +393,7 @@ public struct CPUEngine: EngineType {
     @_specialize(where N == Float)
     private static func reducePrefix<N: NumericType>(
         values: ShapedBuffer<N, CPU>,
-        result: ShapedBuffer<N, CPU>,
+        result: MutableShapedBuffer<N, CPU>,
         reduceColumns: (UnsafeBufferPointer<N>, UnsafeBufferPointer<N>, UnsafeMutableBufferPointer<N>, Int) -> ()
     ) {
         if result.count == 0 {
@@ -404,8 +416,8 @@ public struct CPUEngine: EngineType {
     @_specialize(where N == Float, Context == Int32)
     private static func reduceWithContext<N, Context>(
         values: ShapedBuffer<N, CPU>,
-        result: ShapedBuffer<N, CPU>,
-        context: ShapedBuffer<Context, CPU>,
+        result: MutableShapedBuffer<N, CPU>,
+        context: MutableShapedBuffer<Context, CPU>,
         axis: Int,
         reduceOperator: (UnsafeBufferPointer<N>, Int, Int) -> (N, Context)
     ) {
@@ -449,8 +461,8 @@ public struct CPUEngine: EngineType {
     @_specialize(where N == Float, Context == Int32)
     private static func reduceMultiAxisWithContext<N, Context>(
         values: ShapedBuffer<N, CPU>,
-        result: ShapedBuffer<N, CPU>,
-        context: ShapedBuffer<Context, CPU>,
+        result: MutableShapedBuffer<N, CPU>,
+        context: MutableShapedBuffer<Context, CPU>,
         axes: [Int],
         reduceOperator: (UnsafeBufferPointer<N>, Int) -> (N, Context)
         ) {
@@ -492,8 +504,8 @@ public struct CPUEngine: EngineType {
     @_specialize(where N == Float, Context == Int32)
     private static func reducePrefixWithContext<N: NumericType, Context: NumericType>(
         values: ShapedBuffer<N, CPU>,
-        result: ShapedBuffer<N, CPU>,
-        context: ShapedBuffer<Context, CPU>,
+        result: MutableShapedBuffer<N, CPU>,
+        context: MutableShapedBuffer<Context, CPU>,
         reduceColumns: (UnsafeBufferPointer<N>, UnsafeBufferPointer<N>, UnsafeMutableBufferPointer<N>, UnsafeMutableBufferPointer<Context>, Int) -> ()
     ) {
         if result.count == 0 {
@@ -514,7 +526,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func fillDiagonal<N>(values: ShapedBuffer<N, CPU>, target: ShapedBuffer<N, CPU>) where N : NumericType {
+    public static func fillDiagonal<N>(values: ShapedBuffer<N, CPU>, target: MutableShapedBuffer<N, CPU>) where N : NumericType {
         precondition(values.dim == 1, "values must be a vector")
         precondition(target.dim == 2, "target must be a matrix")
         
@@ -534,7 +546,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func fillDiagonal<N>(value: N, target: ShapedBuffer<N, CPU>) where N : NumericType {
+    public static func fillDiagonal<N>(value: N, target: MutableShapedBuffer<N, CPU>) where N : NumericType {
         precondition(target.dim == 2, "target must be a matrix")
         let maxIdx = Swift.min(target.shape[0], target.shape[1])
         
@@ -550,7 +562,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func extractDiagonal<N>(values: ShapedBuffer<N, CPU>, target: ShapedBuffer<N, CPU>) where N : NumericType {
+    public static func extractDiagonal<N>(values: ShapedBuffer<N, CPU>, target: MutableShapedBuffer<N, CPU>) where N : NumericType {
         precondition(target.dim == 1, "values must be a vector")
         precondition(values.dim == 2, "target must be a matrix")
         
@@ -570,7 +582,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func gemm<N>(lhs: ShapedBuffer<N, CPU>, rhs: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, alpha: N, beta: N, transposeFirst: Bool, transposeSecond: Bool) where N : NumericType {
+    public static func gemm<N>(lhs: ShapedBuffer<N, CPU>, rhs: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, alpha: N, beta: N, transposeFirst: Bool, transposeSecond: Bool) where N : NumericType {
         N.gemm(
             lhs: lhs.values.memory.bindMemory(to: N.self).immutable,
             rhs: rhs.values.memory.bindMemory(to: N.self).immutable,
@@ -586,7 +598,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func broadcastAdd<N: NumericType>(lhs: ShapedBuffer<N, CPU>, rhs: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func broadcastAdd<N: NumericType>(lhs: ShapedBuffer<N, CPU>, rhs: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         broadcast(
             lhs: lhs,
             rhs: rhs,
@@ -598,7 +610,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func broadcastSub<N: NumericType>(lhs: ShapedBuffer<N, CPU>, rhs: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func broadcastSub<N: NumericType>(lhs: ShapedBuffer<N, CPU>, rhs: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         broadcast(
             lhs: lhs,
             rhs: rhs,
@@ -613,7 +625,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func broadcastMul<N: NumericType>(lhs: ShapedBuffer<N, CPU>, rhs: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func broadcastMul<N: NumericType>(lhs: ShapedBuffer<N, CPU>, rhs: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         broadcast(
             lhs: lhs,
             rhs: rhs,
@@ -625,7 +637,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func broadcastDiv<N: NumericType>(lhs: ShapedBuffer<N, CPU>, rhs: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func broadcastDiv<N: NumericType>(lhs: ShapedBuffer<N, CPU>, rhs: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         broadcast(
             lhs: lhs,
             rhs: rhs,
@@ -637,7 +649,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func reduceSum<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, axis: Int) {
+    public static func reduceSum<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, axis: Int) {
         // Choose the operation that performs better
         if axis == 0 && result.shape.reduce(1, *) > 1 {
             reducePrefix(values: values, result: result, reduceColumns: N.vAdd)
@@ -652,7 +664,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func reduceMax<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, context: ShapedBuffer<Int32, CPU>?, axis: Int) {
+    public static func reduceMax<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, context: MutableShapedBuffer<Int32, CPU>?, axis: Int) {
         if let context = context {
             reduceWithContext(
                 values: values,
@@ -678,7 +690,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func reduceMin<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, context: ShapedBuffer<Int32, CPU>?, axis: Int) {
+    public static func reduceMin<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, context: MutableShapedBuffer<Int32, CPU>?, axis: Int) {
         if let context = context {
             reduceWithContext(
                 values: values,
@@ -704,14 +716,14 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func reduceMean<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, axis: Int) {
+    public static func reduceMean<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, axis: Int) {
         reduceSum(values: values, result: result, axis: axis)
         let axisCount = values.shape[axis]
         N.vsMul(lhs: result.immutable, rhs: 1 / N(axisCount), result: result.pointer, count: result.count)
     }
     
     @_specialize(where N == Float)
-    public static func reduceSum<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, axes: [Int]) {
+    public static func reduceSum<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, axes: [Int]) {
         if axes.elementsEqual(0 ..< axes.count) && result.shape.reduce(1, *) > 1 {
             reducePrefix(
                 values: values,
@@ -730,14 +742,14 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func reduceMean<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, axes: [Int]) {
+    public static func reduceMean<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, axes: [Int]) {
         reduceSum(values: values, result: result, axes: axes)
         let axisCount = axes.map {values.shape[$0]}.reduce(1, *)
         N.vsMul(lhs: result.immutable, rhs: 1 / N(axisCount), result: result.pointer, count: result.count)
     }
     
     @_specialize(where N == Float)
-    public static func reduceMax<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, context: ShapedBuffer<Int32, CPU>?, axes: [Int]) {
+    public static func reduceMax<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, context: MutableShapedBuffer<Int32, CPU>?, axes: [Int]) {
         if let context = context {
             reduceMultiAxisWithContext(
                 values: values,
@@ -757,7 +769,7 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func reduceMin<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, context: ShapedBuffer<Int32, CPU>?, axes: [Int]) {
+    public static func reduceMin<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, context: MutableShapedBuffer<Int32, CPU>?, axes: [Int]) {
         if let context = context {
             reduceMultiAxisWithContext(
                 values: values,
@@ -776,27 +788,27 @@ public struct CPUEngine: EngineType {
         }
     }
     
-    public static func scatter<N: NumericType>(reduced: ShapedBuffer<N, CPU>, context: ShapedBuffer<Int32, CPU>, result: ShapedBuffer<N, CPU>, axis: Int, ignoreIndex: Int32) {
+    public static func scatter<N: NumericType>(reduced: ShapedBuffer<N, CPU>, context: ShapedBuffer<Int32, CPU>, result: MutableShapedBuffer<N, CPU>, axis: Int, ignoreIndex: Int32) {
         N.scatter(values: reduced.immutable, context: context.immutable, result: result.pointer, dst_shape: result.shape, axis: axis, ignoreIndex: ignoreIndex)
     }
     
-    public static func gather<N: NumericType>(expanded: ShapedBuffer<N, CPU>, context: ShapedBuffer<Int32, CPU>, result: ShapedBuffer<N, CPU>, axis: Int, ignoreIndex: Int32) {
+    public static func gather<N: NumericType>(expanded: ShapedBuffer<N, CPU>, context: ShapedBuffer<Int32, CPU>, result: MutableShapedBuffer<N, CPU>, axis: Int, ignoreIndex: Int32) {
         N.gather(values: expanded.immutable, context: context.immutable, result: result.pointer, src_shape: expanded.shape, axis: axis, ignoreIndex: ignoreIndex)
     }
     
     @_specialize(where N == Float)
-    public static func sum<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func sum<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         result.values.pointee = N.sum(val: values.immutable, count: values.count)
     }
     
     @_specialize(where N == Float)
-    public static func mean<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func mean<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         result.values.pointee = N.sum(val: values.immutable, count: values.count) / N(values.count)
     }
     
     @discardableResult
     @_specialize(where N == Float)
-    public static func max<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) -> Int {
+    public static func max<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) -> Int {
         let (arg, max) = N.argmax(values: values.immutable, count: values.count)
         result.values.pointee = max
         return arg
@@ -804,35 +816,35 @@ public struct CPUEngine: EngineType {
     
     @discardableResult
     @_specialize(where N == Float)
-    public static func min<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) -> Int {
+    public static func min<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) -> Int {
         let (arg, min) = N.argmin(values: values.immutable, count: values.count)
         result.values.pointee = min
         return arg
     }
     
-    public static func exp<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func exp<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         N.exp(val: values.immutable, result: result.pointer, count: result.count)
     }
     
-    public static func log<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func log<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         N.log(val: values.immutable, result: result.pointer, count: result.count)
     }
     
-    public static func sqrt<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func sqrt<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         N.sqrt(val: values.immutable, result: result.pointer, count: result.count)
     }
     
-    public static func relu<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func relu<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         N.relu(val: values.immutable, result: result.pointer, count: result.count)
     }
     
-    public static func heaviside<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
-        if let values = values as? ShapedBuffer<Float, CPU>, let result = result as? ShapedBuffer<Float, CPU> {
+    public static func heaviside<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
+        if let values = values as? ShapedBuffer<Float, CPU>, let result = result as? MutableShapedBuffer<Float, CPU> {
             Float.heaviside(values: values.immutable, result: result.pointer, count: result.count)
             return
         }
         
-        let srcPtr = values.pointer.pointer(capacity: result.count)
+        let srcPtr = values.immutable.pointer(capacity: result.count)
         let dstPtr = result.pointer.pointer(capacity: result.count)
         
         for i in 0 ..< result.count {
@@ -840,38 +852,38 @@ public struct CPUEngine: EngineType {
         }
     }
     
-    public static func sin<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func sin<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         N.sin(values: values.immutable, result: result.pointer, count: result.count)
     }
     
-    public static func cos<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func cos<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         N.cos(values: values.immutable, result: result.pointer, count: result.count)
     }
     
-    public static func tan<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func tan<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         N.tan(values: values.immutable, result: result.pointer, count: result.count)
     }
     
-    public static func sinh<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func sinh<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         fatalError("\(#function) is not implemented for type \(self)")
     }
     
-    public static func cosh<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func cosh<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         fatalError("\(#function) is not implemented for type \(self)")
     }
     
-    public static func tanh<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func tanh<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         N.tanh(val: values.immutable, result: result.pointer, count: result.count)
     }
     
-    public static func max<N>(_ lhs: ShapedBuffer<N, CPU>, _ rhs: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) where N : NumericType {
+    public static func max<N>(_ lhs: ShapedBuffer<N, CPU>, _ rhs: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) where N : NumericType {
         precondition(lhs.shape == rhs.shape, "Shapes of lhs and rhs must match")
         precondition(lhs.shape == result.shape, "Shapes of inputs and result must match")
         
         N.max(lhs: lhs.immutable, rhs: rhs.immutable, result: result.pointer, count: result.count)
     }
     
-    public static func max<N>(_ lhs: ShapedBuffer<N, CPU>, _ rhs: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, context: ShapedBuffer<N, CPU>) where N : NumericType {
+    public static func max<N>(_ lhs: ShapedBuffer<N, CPU>, _ rhs: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, context: MutableShapedBuffer<N, CPU>) where N : NumericType {
         precondition(lhs.shape == rhs.shape, "Shapes of lhs and rhs must match")
         precondition(lhs.shape == result.shape, "Shapes of inputs and result must match")
         precondition(context.shape == result.shape, "Shapes of context and result must match")
@@ -879,14 +891,14 @@ public struct CPUEngine: EngineType {
         N.max(lhs: lhs.immutable, rhs: rhs.immutable, result: result.pointer, context: context.pointer, count: result.count)
     }
     
-    public static func min<N>(_ lhs: ShapedBuffer<N, CPU>, _ rhs: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) where N : NumericType {
+    public static func min<N>(_ lhs: ShapedBuffer<N, CPU>, _ rhs: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) where N : NumericType {
         precondition(lhs.shape == rhs.shape, "Shapes of lhs and rhs must match")
         precondition(lhs.shape == result.shape, "Shapes of inputs and result must match")
         
         N.min(lhs: lhs.immutable, rhs: rhs.immutable, result: result.pointer, count: result.count)
     }
     
-    public static func min<N>(_ lhs: ShapedBuffer<N, CPU>, _ rhs: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, context: ShapedBuffer<N, CPU>) where N : NumericType {
+    public static func min<N>(_ lhs: ShapedBuffer<N, CPU>, _ rhs: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, context: MutableShapedBuffer<N, CPU>) where N : NumericType {
         precondition(lhs.shape == rhs.shape, "Shapes of lhs and rhs must match")
         precondition(lhs.shape == result.shape, "Shapes of inputs and result must match")
         precondition(context.shape == result.shape, "Shapes of context and result must match")
@@ -894,7 +906,7 @@ public struct CPUEngine: EngineType {
         N.min(lhs: lhs.immutable, rhs: rhs.immutable, result: result.pointer, context: context.pointer, count: result.count)
     }
     
-    public static func permuteAxes<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, arangement: [Int]) {
+    public static func permuteAxes<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, arangement: [Int]) {
         let dim = values.dim
         
         if dim == 2 && arangement == [1, 0] {
@@ -930,11 +942,11 @@ public struct CPUEngine: EngineType {
                 dstIdx += indices[offset + i] * dstStrides[arangement[i]]
             }
             
-            dstMem.advanced(by: dstIdx).assign(from: sourceMem.advanced(by: srcIdx), count: copyCount)
+            dstMem.advanced(by: dstIdx).update(from: sourceMem.advanced(by: srcIdx), count: copyCount)
         }
     }
     
-    public static func permuteAxesAdd<N: NumericType>(values: ShapedBuffer<N, CPU>, add: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, arangement: [Int]) {
+    public static func permuteAxesAdd<N: NumericType>(values: ShapedBuffer<N, CPU>, add: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, arangement: [Int]) {
         let sourceMem = values.immutable
         let addMem = add.immutable
         let dstMem = result.pointer
@@ -966,11 +978,11 @@ public struct CPUEngine: EngineType {
         }
     }
     
-    public static func arange<N: NumericType>(lowerBound: N, upperBound: N, result: ShapedBuffer<N, CPU>) {
+    public static func arange<N: NumericType>(lowerBound: N, upperBound: N, result: MutableShapedBuffer<N, CPU>) {
         N.arange(start: lowerBound, end: upperBound, result: result.pointer, count: result.count)
     }
     
-    public static func subscriptRead<N>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, index: [Int?]) {
+    public static func subscriptRead<N>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, index: [Int?]) {
         let (buffer, isCopy, bufferShape) = CPU.Memory.get(slice: index, of: values.values, with: values.shape)
         
         result.pointer.assign(from: buffer.immutable, count: bufferShape.reduce(1, *))
@@ -980,19 +992,19 @@ public struct CPUEngine: EngineType {
         }
     }
     
-    public static func subscriptWrite<N>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, index: [Int?]) {
+    public static func subscriptWrite<N>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, index: [Int?]) {
         fatalError("\(#function) is not implemented for type \(self)")
     }
     
-    public static func subscriptReadAdd<N: NumericType>(values: ShapedBuffer<N, CPU>, add: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, index: [Int?]) {
+    public static func subscriptReadAdd<N: NumericType>(values: ShapedBuffer<N, CPU>, add: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, index: [Int?]) {
         fatalError("\(#function) is not implemented for type \(self)")
     }
     
-    public static func subscriptWriteAdd<N: NumericType>(values: ShapedBuffer<N, CPU>, add: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, index: [Int?]) {
+    public static func subscriptWriteAdd<N: NumericType>(values: ShapedBuffer<N, CPU>, add: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, index: [Int?]) {
         fatalError("\(#function) is not implemented for type \(self)")
     }
     
-    public static func stack<N>(buffers: [ShapedBuffer<N, CPU>], result: ShapedBuffer<N, CPU>, axis: Int) {
+    public static func stack<N>(buffers: [ShapedBuffer<N, CPU>], result: MutableShapedBuffer<N, CPU>, axis: Int) {
         var offset = 0
         
         let dstPtr = result.pointer.pointer(capacity: buffers.map {$0.count}.reduce(0, +))
@@ -1022,7 +1034,7 @@ public struct CPUEngine: EngineType {
         }
     }
     
-    public static func unstackAdd<N: NumericType>(stacked: ShapedBuffer<N, CPU>, add: [ShapedBuffer<N, CPU>], result: [ShapedBuffer<N, CPU>], axis: Int) {
+    public static func unstackAdd<N: NumericType>(stacked: ShapedBuffer<N, CPU>, add: [ShapedBuffer<N, CPU>], result: [MutableShapedBuffer<N, CPU>], axis: Int) {
         var offset = 0
         
         let srcPtr = stacked.immutable
@@ -1053,7 +1065,7 @@ public struct CPUEngine: EngineType {
         }
     }
     
-    public static func unstack<N>(stacked: ShapedBuffer<N, CPU>, result: [ShapedBuffer<N, CPU>], axis: Int) where N : NumericType {
+    public static func unstack<N>(stacked: ShapedBuffer<N, CPU>, result: [MutableShapedBuffer<N, CPU>], axis: Int) where N : NumericType {
         var offset = 0
         
         let srcPtr = stacked.immutable
@@ -1083,31 +1095,31 @@ public struct CPUEngine: EngineType {
         }
     }
     
-    public static func reverse<N>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func reverse<N>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         precondition(values.shape == result.shape)
         
         let stride = CPU.Memory.strides(from: values.shape)[0]
         let count = values.shape[0]
         
         let srcPtr = values.immutable.pointer(capacity: stride * count)
-        let dstPtr = values.pointer.pointer(capacity: stride * count)
+        let dstPtr = result.pointer.pointer(capacity: stride * count)
         
         for srcIdx in 0 ..< count {
             let dstIdx = count - srcIdx - 1
             
-            dstPtr.advanced(by: dstIdx * stride).assign(from: srcPtr.advanced(by: srcIdx * stride), count: stride)
+            dstPtr.advanced(by: dstIdx * stride).update(from: srcPtr.advanced(by: srcIdx * stride), count: stride)
         }
     }
     
-    public static func reverseAdd<N: NumericType>(values: ShapedBuffer<N, CPU>, add: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>) {
+    public static func reverseAdd<N: NumericType>(values: ShapedBuffer<N, CPU>, add: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>) {
         precondition(values.shape == result.shape && values.shape == add.shape)
         
         let stride = CPU.Memory.strides(from: values.shape)[0]
         let count = values.shape[0]
         
         let srcPtr = values.immutable
-        let addPtr = values.immutable
-        let dstPtr = values.pointer
+        let addPtr = add.immutable
+        let dstPtr = result.pointer
         
         for srcIdx in 0 ..< count {
             let dstIdx = count - srcIdx - 1
@@ -1121,18 +1133,18 @@ public struct CPUEngine: EngineType {
     }
     
     @_specialize(where N == Float)
-    public static func img2col<N: NumericType>(values: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, kernelWidth: Int, kernelHeight: Int, padding: Int, stride: Int) {
+    public static func img2col<N: NumericType>(values: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, kernelWidth: Int, kernelHeight: Int, padding: Int, stride: Int) {
         precondition(values.dim == 4, "im2col input must be 4D tensor (batchSize x channels x height x width)")
         N.img2col(values: values.immutable, result: result.pointer, batchSize: values.shape[0], channels: values.shape[1], height: values.shape[2], width: values.shape[3], kernelHeight: kernelHeight, kernelWidth: kernelWidth, padding: padding, stride: stride);
     }
     
     @_specialize(where N == Float)
-    public static func col2img<N: NumericType>(matrix: ShapedBuffer<N, CPU>, image: ShapedBuffer<N, CPU>, kernelWidth: Int, kernelHeight: Int, padding: Int, stride: Int) {
+    public static func col2img<N: NumericType>(matrix: ShapedBuffer<N, CPU>, image: MutableShapedBuffer<N, CPU>, kernelWidth: Int, kernelHeight: Int, padding: Int, stride: Int) {
         precondition(image.dim == 4, "im2col input must be 4D tensor (batchSize x channels x height x width)")
         N.col2img(values: matrix.immutable, result: image.pointer, batchSize: image.shape[0], channels: image.shape[1], height: image.shape[2], width: image.shape[3], kernelHeight: kernelHeight, kernelWidth: kernelWidth, padding: padding, stride: stride);
     }
     
-    public static func band<N>(buffer: ShapedBuffer<N, CPU>, result: ShapedBuffer<N, CPU>, belowDiagonal: Int?, aboveDiagonal: Int?) where N : NumericType {
+    public static func band<N>(buffer: ShapedBuffer<N, CPU>, result: MutableShapedBuffer<N, CPU>, belowDiagonal: Int?, aboveDiagonal: Int?) where N : NumericType {
         precondition(buffer.shape == result.shape, "Shape of result must be equal to shape of buffer.")
         precondition(buffer.dim == 2, "Band can only be computed on tensor of dimensionality 2.")
         

--- a/Sources/DL4S/Engine/Engine.swift
+++ b/Sources/DL4S/Engine/Engine.swift
@@ -46,35 +46,25 @@ public protocol MemoryOperatorsType {
     /// - Parameters:
     ///   - withCapacity: Capacity to reserve
     ///   - type: Type of elements in the buffer
-    static func allocateBuffer<Element>(withCapacity: Int, type: Element.Type) -> Buffer<Element, Device>
-    
-    /// Allocates a buffer with capacity for the amount of elements in the given shape
-    /// - Parameters:
-    ///   - shape: Shape of the buffer to allocate
-    ///   - type: Type of elements in the buffer
-    static func allocateBuffer<Element>(withShape shape: [Int], type: Element.Type) -> ShapedBuffer<Element, Device>
+    static func allocateBuffer<Element>(withCapacity: Int, type: Element.Type) -> MutableBuffer<Element, Device>
     
     /// Releases all resources associated with the given buffer
     /// - Parameter buffer: Buffer to release
-    static func free<Element>(_ buffer: Buffer<Element, Device>)
-    
-    /// Releases all resources associated with the given buffer
-    /// - Parameter buffer: Buffer to release
-    static func free<Element>(_ buffer: ShapedBuffer<Element, Device>)
+    static func free<Element>(_ buffer: MutableBuffer<Element, Device>)
     
     /// Copies values from the given host buffer to the memory of the device
     /// - Parameters:
     ///   - source: Source buffer
     ///   - destination: Device buffer
     ///   - count: Number of elements to copy
-    static func assign<Element>(from source: UnsafeBufferPointer<Element>, to destination: Buffer<Element, Device>, count: Int)
+    static func assign<Element>(from source: UnsafeBufferPointer<Element>, to destination: MutableBuffer<Element, Device>, count: Int)
     
     /// Copies values between two device buffers
     /// - Parameters:
     ///   - source: Source device buffer
     ///   - destination: Target device buffer
     ///   - count: Number of elements to copy
-    static func assign<Element>(from source: Buffer<Element, Device>, to destination: Buffer<Element, Device>, count: Int)
+    static func assign<Element>(from source: Buffer<Element, Device>, to destination: MutableBuffer<Element, Device>, count: Int)
     
     /// Copies values from the given device buffer to the given host buffer
     /// - Parameters:
@@ -97,7 +87,8 @@ public protocol MemoryOperatorsType {
     ///   - buffer: Buffer to read from
     ///   - shape: Shape of the buffer
     /// - Returns: The result buffer, a boolean indicating whether the result buffer is a copy (true) or a pointer in the same memory region (false) and the shape of the result.
-    static func get<Element>(slice: [Int?], of buffer: Buffer<Element, Device>, with shape: [Int]) -> (Buffer<Element, Device>, Bool, [Int])
+    ///   The result becomes the storage of a new tensor handle. When it is not a copy, that handle must list the source as its parent.
+    static func get<Element>(slice: [Int?], of buffer: Buffer<Element, Device>, with shape: [Int]) -> (MutableBuffer<Element, Device>, Bool, [Int])
     
     /// Retrieves a slice of values from the given buffer
     /// - Parameters:
@@ -105,7 +96,8 @@ public protocol MemoryOperatorsType {
     ///   - buffer: Buffer to read from
     ///   - shape: Shape of the buffer
     /// - Returns: The result buffer, a boolean indicating whether the result buffer is a copy (true) or a pointer in the same memory region (false) and the shape of the result.
-    static func get<Element>(slice: [(CountableRange<Int>)?], of buffer: Buffer<Element, Device>, with shape: [Int]) -> (Buffer<Element, Device>, Bool, [Int])
+    ///   The result becomes the storage of a new tensor handle. When it is not a copy, that handle must list the source as its parent.
+    static func get<Element>(slice: [(CountableRange<Int>)?], of buffer: Buffer<Element, Device>, with shape: [Int]) -> (MutableBuffer<Element, Device>, Bool, [Int])
     
     /// Writes a slice into a target buffer
     /// - Parameters:
@@ -114,7 +106,7 @@ public protocol MemoryOperatorsType {
     ///   - dstShape: Shape of the destination buffer
     ///   - source: Buffer to read from
     ///   - sourceShape: Shape of the source buffer
-    static func set<Element>(slice: [Int?], of buffer: Buffer<Element, Device>, with dstShape: [Int], from source: Buffer<Element, Device>, with sourceShape: [Int])
+    static func set<Element>(slice: [Int?], of buffer: MutableBuffer<Element, Device>, with dstShape: [Int], from source: Buffer<Element, Device>, with sourceShape: [Int])
     
     /// Writes a slice into a target buffer
     /// - Parameters:
@@ -123,19 +115,25 @@ public protocol MemoryOperatorsType {
     ///   - dstShape: Shape of the destination buffer
     ///   - source: Buffer to read from
     ///   - sourceShape: Shape of the source buffer
-    static func set<Element>(slice: [Range<Int>?], of buffer: Buffer<Element, Device>, with dstShape: [Int], from source: Buffer<Element, Device>, with sourceShape: [Int])
+    static func set<Element>(slice: [Range<Int>?], of buffer: MutableBuffer<Element, Device>, with dstShape: [Int], from source: Buffer<Element, Device>, with sourceShape: [Int])
     
     /// Sets the first element of the device buffer
     /// - Parameters:
     ///   - buffer: Target buffer
     ///   - newValue: Value to set the first slot of the target to
-    static func setPointee<Element>(of buffer: Buffer<Element, Device>, to newValue: Element)
+    static func setPointee<Element>(of buffer: MutableBuffer<Element, Device>, to newValue: Element)
     
     /// Returns a buffer that uses the same region of memory but is advanced by the given number of elements
     /// - Parameters:
     ///   - buffer: Parent buffer
     ///   - advancement: Number of elements to advance the start index by
     static func advance<Element>(buffer: Buffer<Element, Device>, by advancement: Int) -> Buffer<Element, Device>
+    
+    /// Returns a buffer that points to the memory of the given buffer offset by the given number of elements
+    /// - Parameters:
+    ///   - buffer: Buffer to offset
+    ///   - advancement: Number of elements to advance by
+    static func advance<Element>(buffer: MutableBuffer<Element, Device>, by advancement: Int) -> MutableBuffer<Element, Device>
 }
 
 //MARK: Engine
@@ -150,7 +148,7 @@ public protocol EngineType {
     ///   - value: Value to fill the buffer with
     ///   - result: Buffer to fill
     ///   - count: Number of elements to write
-    static func fill<N: NumericType>(value: N, result: Buffer<N, Device>, count: Int)
+    static func fill<N: NumericType>(value: N, result: MutableBuffer<N, Device>, count: Int)
     
     /// Element-wise Vector-vector add
     /// - Parameters:
@@ -158,14 +156,14 @@ public protocol EngineType {
     ///   - rhs: Second summand
     ///   - result: Result buffer
     ///   - count: Number of elements to add
-    static func vAdd<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: Buffer<N, Device>, count: Int)
+    static func vAdd<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: MutableBuffer<N, Device>, count: Int)
     
     /// Element-wise Vector negate
     /// - Parameters:
     ///   - val: Vector to negate
     ///   - result: Result buffer
     ///   - count: Number of elements to negate
-    static func vNeg<N: NumericType>(val: Buffer<N, Device>, result: Buffer<N, Device>, count: Int)
+    static func vNeg<N: NumericType>(val: Buffer<N, Device>, result: MutableBuffer<N, Device>, count: Int)
     
     /// Element-wise Vector-vector subtract
     /// - Parameters:
@@ -173,7 +171,7 @@ public protocol EngineType {
     ///   - rhs: Right-hand side vector
     ///   - result: Result bufffer
     ///   - count: Number of elements to subtract
-    static func vSub<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: Buffer<N, Device>, count: Int)
+    static func vSub<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: MutableBuffer<N, Device>, count: Int)
     
     /// Element-wise Vector-vector multiply
     /// - Parameters:
@@ -181,7 +179,7 @@ public protocol EngineType {
     ///   - rhs: Second factor
     ///   - result: Result buffer
     ///   - count: Number of elements to multiply
-    static func vMul<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: Buffer<N, Device>, count: Int)
+    static func vMul<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: MutableBuffer<N, Device>, count: Int)
     
     /// Element-wise Vector-vector divide
     /// - Parameters:
@@ -189,7 +187,7 @@ public protocol EngineType {
     ///   - rhs: Divisor
     ///   - result: Result buffer
     ///   - count: Number of elements to divide
-    static func vDiv<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: Buffer<N, Device>, count: Int)
+    static func vDiv<N: NumericType>(lhs: Buffer<N, Device>, rhs: Buffer<N, Device>, result: MutableBuffer<N, Device>, count: Int)
 
     //MARK: Matrix operations
     
@@ -198,20 +196,20 @@ public protocol EngineType {
     /// - Parameters:
     ///   - values: Values to fill the diagonal with
     ///   - target: Matrix to be filled
-    static func fillDiagonal<N: NumericType>(values: ShapedBuffer<N, Device>, target: ShapedBuffer<N, Device>)
+    static func fillDiagonal<N: NumericType>(values: ShapedBuffer<N, Device>, target: MutableShapedBuffer<N, Device>)
     
     /// Matrix diagonal fill in-place
     /// - Parameters:
     ///   - value: Value to fill the diagonal with
     ///   - target: Matrix to be filled
-    static func fillDiagonal<N: NumericType>(value: N, target: ShapedBuffer<N, Device>)
+    static func fillDiagonal<N: NumericType>(value: N, target: MutableShapedBuffer<N, Device>)
     
     
     /// Extracts the diagonal of a matrix
     /// - Parameters:
     ///   - value: Matrix to extract diagonal from
     ///   - target: Vector to write diagonal values to
-    static func extractDiagonal<N: NumericType>(values: ShapedBuffer<N, Device>, target: ShapedBuffer<N, Device>)
+    static func extractDiagonal<N: NumericType>(values: ShapedBuffer<N, Device>, target: MutableShapedBuffer<N, Device>)
     
     /// Matrix multiply add in-place
     /// - Parameters:
@@ -222,7 +220,7 @@ public protocol EngineType {
     ///   - beta: Add scale
     ///   - transposeFirst: Whether to transpose the first matrix
     ///   - transposeSecond: Whether to transpose the second matrix
-    static func gemm<N: NumericType>(lhs: ShapedBuffer<N, Device>, rhs: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, alpha: N, beta: N, transposeFirst: Bool, transposeSecond: Bool)
+    static func gemm<N: NumericType>(lhs: ShapedBuffer<N, Device>, rhs: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, alpha: N, beta: N, transposeFirst: Bool, transposeSecond: Bool)
     
     /// Band matrix extraction
     /// - Parameters:
@@ -230,7 +228,7 @@ public protocol EngineType {
     ///   - result: Result buffer
     ///   - belowDiagonal: Number of elements below diagonal to keep, nil for all elements
     ///   - aboveDiagonal: Number of elements above diagonal to keep, nil for all elements
-    static func band<N: NumericType>(buffer: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, belowDiagonal: Int?, aboveDiagonal: Int?)
+    static func band<N: NumericType>(buffer: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, belowDiagonal: Int?, aboveDiagonal: Int?)
     
     //MARK: Broadcasting
     
@@ -239,28 +237,28 @@ public protocol EngineType {
     ///   - lhs: First summand
     ///   - rhs: Second summand
     ///   - result: Sum vector
-    static func broadcastAdd<N: NumericType>(lhs: ShapedBuffer<N, Device>, rhs: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func broadcastAdd<N: NumericType>(lhs: ShapedBuffer<N, Device>, rhs: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Broadcast subtracts one vector from another
     /// - Parameters:
     ///   - lhs: Left-hand side vector
     ///   - rhs: Vector to subtact from lhs
     ///   - result: Result buffer
-    static func broadcastSub<N: NumericType>(lhs: ShapedBuffer<N, Device>, rhs: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func broadcastSub<N: NumericType>(lhs: ShapedBuffer<N, Device>, rhs: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Broadcast multiplies two buffers
     /// - Parameters:
     ///   - lhs: First factor
     ///   - rhs: Second factor
     ///   - result: Product vector
-    static func broadcastMul<N: NumericType>(lhs: ShapedBuffer<N, Device>, rhs: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func broadcastMul<N: NumericType>(lhs: ShapedBuffer<N, Device>, rhs: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Broadcast divides one vector by another
     /// - Parameters:
     ///   - lhs: Left-hand side vector
     ///   - rhs: Vector to divide lhs with
     ///   - result: Result buffer
-    static func broadcastDiv<N: NumericType>(lhs: ShapedBuffer<N, Device>, rhs: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func broadcastDiv<N: NumericType>(lhs: ShapedBuffer<N, Device>, rhs: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     //MARK: Reduction
     
@@ -269,7 +267,7 @@ public protocol EngineType {
     ///   - values: Buffer to reduce
     ///   - result: Result buffer
     ///   - axis: Axis to reduce along
-    static func reduceSum<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, axis: Int)
+    static func reduceSum<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, axis: Int)
     
     /// Reduces one buffer into another along one axis by computing the maximum.
     /// - Parameters:
@@ -277,7 +275,7 @@ public protocol EngineType {
     ///   - result: Result buffer
     ///   - context: Context vector that stores the argmax
     ///   - axis: Axis to reduce along
-    static func reduceMax<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, context: ShapedBuffer<Int32, Device>?, axis: Int)
+    static func reduceMax<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, context: MutableShapedBuffer<Int32, Device>?, axis: Int)
     
     /// Reduces one buffer into another along one axis by computing the minimum.
     /// - Parameters:
@@ -285,21 +283,21 @@ public protocol EngineType {
     ///   - result: Result buffer
     ///   - context: Context vector that stores the argmin
     ///   - axis: Axis to reduce along
-    static func reduceMin<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, context: ShapedBuffer<Int32, Device>?, axis: Int)
+    static func reduceMin<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, context: MutableShapedBuffer<Int32, Device>?, axis: Int)
     
     /// Reduces one buffer into another along one axis by computing the mean.
     /// - Parameters:
     ///   - values: Buffer to reduce
     ///   - result: Result buffer
     ///   - axis: Axis to reduce along
-    static func reduceMean<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, axis: Int)
+    static func reduceMean<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, axis: Int)
     
     /// Reduces one buffer into another along multiple axes by computing the sum.
     /// - Parameters:
     ///   - values: Buffer to reduce
     ///   - result: Result buffer
     ///   - axes: Axes to reduce along
-    static func reduceSum<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, axes: [Int])
+    static func reduceSum<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, axes: [Int])
     
     /// Reduces one buffer into another along multiple axes by computing the maximum.
     /// - Parameters:
@@ -307,7 +305,7 @@ public protocol EngineType {
     ///   - result: Result buffer
     ///   - context: Context buffer that stores the argmax
     ///   - axes: Axes to reduce along
-    static func reduceMax<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, context: ShapedBuffer<Int32, Device>?, axes: [Int])
+    static func reduceMax<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, context: MutableShapedBuffer<Int32, Device>?, axes: [Int])
     
     /// Reduces one buffer into another along multiple axes by computing the minimum.
     /// - Parameters:
@@ -315,38 +313,38 @@ public protocol EngineType {
     ///   - result: Result buffer
     ///   - context: Context buffer that stores the argmin
     ///   - axes: Axes to reduce along
-    static func reduceMin<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, context: ShapedBuffer<Int32, Device>?, axes: [Int])
+    static func reduceMin<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, context: MutableShapedBuffer<Int32, Device>?, axes: [Int])
     
     /// Reduces one buffer into another along multiple axes by computing the mean.
     /// - Parameters:
     ///   - values: Buffer to reduce
     ///   - result: Result buffer
     ///   - axes: Axes to reduce along
-    static func reduceMean<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, axes: [Int])
+    static func reduceMean<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, axes: [Int])
     
     /// Computes the sum of a buffer
     /// - Parameters:
     ///   - values: Buffer to sum up
     ///   - result: Result buffer
-    static func sum<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func sum<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Computes the mean of a buffer
     /// - Parameters:
     ///   - values: Buffer to compute the mean of
     ///   - result: Result buffer
-    static func mean<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func mean<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Stores the maximum value in result and returns the argmax
     /// - Parameters:
     ///   - values: Value buffer
     ///   - result: Result buffer
-    @discardableResult static func max<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>) -> Int
+    @discardableResult static func max<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>) -> Int
     
     /// Stores the minimum value in result and returns the argmin
     /// - Parameters:
     ///   - values: Value buffer
     ///   - result: Result buffer
-    @discardableResult static func min<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>) -> Int
+    @discardableResult static func min<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>) -> Int
     
     /// Computes the argmax of a buffer
     /// - Parameters:
@@ -360,74 +358,74 @@ public protocol EngineType {
     /// - Parameters:
     ///   - values: Buffer of values to exponentiate
     ///   - result: Result buffer
-    static func exp<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func exp<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise log
     /// - Parameters:
     ///   - values: Buffer of values to compute the log of
     ///   - result: Result buffer
-    static func log<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func log<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise square root
     /// - Parameters:
     ///   - values: Buffer of values to compute the square root of
     ///   - result: Result buffer
-    static func sqrt<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func sqrt<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise recitified linear unit
     /// - Parameters:
     ///   - values: Buffer of values to compute the relu of
     ///   - result: Result buffer
-    static func relu<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func relu<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise heaviside step function
     /// - Parameters:
     ///   - values: Buffer of values to compute the heaviside step function of
     ///   - result: Result buffer
-    static func heaviside<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func heaviside<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise sine
     /// - Parameters:
     ///   - values: Buffer of values to compute the sine of
     ///   - result: Result buffer
-    static func sin<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func sin<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise cosine
     /// - Parameters:
     ///   - values: Buffer of values to compute the cosine of
     ///   - result: Result buffer
-    static func cos<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func cos<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise tangent
     /// - Parameters:
     ///   - values: Buffer of values to compute the tangent of
     ///   - result: Result buffer
-    static func tan<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func tan<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise hyperbolic sine
     /// - Parameters:
     ///   - values: Buffer of values to compute the hyperbolic sine of
     ///   - result: Result buffer
-    static func sinh<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func sinh<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise hyperbolic cosine
     /// - Parameters:
     ///   - values: Buffer of values to compute the hyperbolic cosine of
     ///   - result: Result buffer
-    static func cosh<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func cosh<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise hyperbolic tangent
     /// - Parameters:
     ///   - values: Buffer of values to compute the hyperbolic tangent of
     ///   - result: Result buffer
-    static func tanh<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func tanh<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise maximum
     /// - Parameters:
     ///   - lhs: First buffer
     ///   - rhs: Second buffer
     ///   - result: Result buffer
-    static func max<N: NumericType>(_ lhs: ShapedBuffer<N, Device>, _ rhs: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func max<N: NumericType>(_ lhs: ShapedBuffer<N, Device>, _ rhs: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise maximum
     /// - Parameters:
@@ -435,14 +433,14 @@ public protocol EngineType {
     ///   - rhs: Second buffer
     ///   - result: Result buffer
     ///   - context: Context buffer
-    static func max<N: NumericType>(_ lhs: ShapedBuffer<N, Device>, _ rhs: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, context: ShapedBuffer<N, Device>)
+    static func max<N: NumericType>(_ lhs: ShapedBuffer<N, Device>, _ rhs: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, context: MutableShapedBuffer<N, Device>)
     
     /// Element-wise minimum
     /// - Parameters:
     ///   - lhs: First buffer
     ///   - rhs: Second buffer
     ///   - result: Result buffer
-    static func min<N: NumericType>(_ lhs: ShapedBuffer<N, Device>, _ rhs: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func min<N: NumericType>(_ lhs: ShapedBuffer<N, Device>, _ rhs: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Element-wise minimum
     /// - Parameters:
@@ -450,7 +448,7 @@ public protocol EngineType {
     ///   - rhs: Second buffer
     ///   - result: Result buffer
     ///   - context: Context buffer
-    static func min<N: NumericType>(_ lhs: ShapedBuffer<N, Device>, _ rhs: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, context: ShapedBuffer<N, Device>)
+    static func min<N: NumericType>(_ lhs: ShapedBuffer<N, Device>, _ rhs: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, context: MutableShapedBuffer<N, Device>)
     
     //MARK: Shuffling
     
@@ -460,7 +458,7 @@ public protocol EngineType {
     ///   - context: Index vector
     ///   - result: Buffer to scatter to
     ///   - axis: Axis to scatter along
-    static func scatter<N: NumericType>(reduced: ShapedBuffer<N, Device>, context: ShapedBuffer<Int32, Device>, result: ShapedBuffer<N, Device>, axis: Int, ignoreIndex: Int32)
+    static func scatter<N: NumericType>(reduced: ShapedBuffer<N, Device>, context: ShapedBuffer<Int32, Device>, result: MutableShapedBuffer<N, Device>, axis: Int, ignoreIndex: Int32)
     
     /// Gathers elements from indices determined by the context along the specified axis
     /// - Parameters:
@@ -468,14 +466,14 @@ public protocol EngineType {
     ///   - context: Index vector
     ///   - result: Result buffer
     ///   - axis: Axis to gather along
-    static func gather<N: NumericType>(expanded: ShapedBuffer<N, Device>, context: ShapedBuffer<Int32, Device>, result: ShapedBuffer<N, Device>, axis: Int, ignoreIndex: Int32)
+    static func gather<N: NumericType>(expanded: ShapedBuffer<N, Device>, context: ShapedBuffer<Int32, Device>, result: MutableShapedBuffer<N, Device>, axis: Int, ignoreIndex: Int32)
     
     /// Performs an axis permutation / transpose oepration
     /// - Parameters:
     ///   - values: Buffer of values to permute
     ///   - result: Result buffer
     ///   - arangement: Arangement of axes.
-    static func permuteAxes<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, arangement: [Int])
+    static func permuteAxes<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, arangement: [Int])
     
     /// Performs an axis permutation / transpose oepration and adds another value vector
     /// - Parameters:
@@ -483,21 +481,21 @@ public protocol EngineType {
     ///   - add: Buffer of values to add to the result
     ///   - result: Result buffer
     ///   - arangement: Arangement of axes.
-    static func permuteAxesAdd<N: NumericType>(values: ShapedBuffer<N, Device>, add: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, arangement: [Int])
+    static func permuteAxesAdd<N: NumericType>(values: ShapedBuffer<N, Device>, add: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, arangement: [Int])
     
     /// Reads elements from the given index
     /// - Parameters:
     ///   - values: Buffer of values to read
     ///   - result: Buffer to write the values to
     ///   - index: Index to read from, nil values indicate that all values along the corresponding axis should be read
-    static func subscriptRead<N>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, index: [Int?])
+    static func subscriptRead<N>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, index: [Int?])
     
     /// Writes elements to the result tensor at the given index
     /// - Parameters:
     ///   - values: Values to write
     ///   - result: Buffer to write to
     ///   - index: Index to write to, nil values indicate that all values along the corresponding axis should be written
-    static func subscriptWrite<N>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, index: [Int?])
+    static func subscriptWrite<N>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, index: [Int?])
     
     /// Reads elements from the given index and adds a second vector
     /// - Parameters:
@@ -505,7 +503,7 @@ public protocol EngineType {
     ///   - add: Buffer to add
     ///   - result: Buffer to write the values to
     ///   - index: Index to read from, nil values indicate that all values along the corresponding axis should be read
-    static func subscriptReadAdd<N: NumericType>(values: ShapedBuffer<N, Device>, add: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, index: [Int?])
+    static func subscriptReadAdd<N: NumericType>(values: ShapedBuffer<N, Device>, add: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, index: [Int?])
     
     /// Writes elements to the result tensor at the given index and adds a second vector
     /// - Parameters:
@@ -513,27 +511,27 @@ public protocol EngineType {
     ///   - add: Buffer to add
     ///   - result: Buffer to write to
     ///   - index: Index to write to, nil values indicate that all values along the corresponding axis should be written
-    static func subscriptWriteAdd<N: NumericType>(values: ShapedBuffer<N, Device>, add: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, index: [Int?])
+    static func subscriptWriteAdd<N: NumericType>(values: ShapedBuffer<N, Device>, add: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, index: [Int?])
     
     /// Reverses the order of elements along the first dimension of the buffer
     /// - Parameters:
     ///   - values: Buffer to reverse
     ///   - result: Result buffer
-    static func reverse<N>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func reverse<N>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Reverses the order of elements along the first dimension of the buffer and adds a second buffer
     /// - Parameters:
     ///   - values: Buffer to reverse
     ///   - add: Buffer to add
     ///   - result: Result buffer
-    static func reverseAdd<N: NumericType>(values: ShapedBuffer<N, Device>, add: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>)
+    static func reverseAdd<N: NumericType>(values: ShapedBuffer<N, Device>, add: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>)
     
     /// Stacks the given array of buffers along the stacking axis into the result buffer.
     /// - Parameters:
     ///   - buffers: Buffers to stack
     ///   - result: Result buffer
     ///   - axis: Axis to stack the buffers along
-    static func stack<N>(buffers: [ShapedBuffer<N, Device>], result: ShapedBuffer<N, Device>, axis: Int)
+    static func stack<N>(buffers: [ShapedBuffer<N, Device>], result: MutableShapedBuffer<N, Device>, axis: Int)
     
     /// Reverses the stacking operation and adds a list of buffers to the unstacked results
     /// - Parameters:
@@ -541,21 +539,21 @@ public protocol EngineType {
     ///   - add: Buffers to add to the corresponding result buffers
     ///   - result: Buffers to write the result to
     ///   - axis: Axis to unstack along
-    static func unstackAdd<N: NumericType>(stacked: ShapedBuffer<N, Device>, add: [ShapedBuffer<N, Device>], result: [ShapedBuffer<N, Device>], axis: Int)
+    static func unstackAdd<N: NumericType>(stacked: ShapedBuffer<N, Device>, add: [ShapedBuffer<N, Device>], result: [MutableShapedBuffer<N, Device>], axis: Int)
     
     /// Reverses the stacking operation
     /// - Parameters:
     ///   - stacked: Buffer that stores elements of stacked buffers
     ///   - result: Buffers to write the result to
     ///   - axis: Axis to unstack along
-    static func unstack<N: NumericType>(stacked: ShapedBuffer<N, Device>, result: [ShapedBuffer<N, Device>], axis: Int)
+    static func unstack<N: NumericType>(stacked: ShapedBuffer<N, Device>, result: [MutableShapedBuffer<N, Device>], axis: Int)
     
     /// Writes linear interpolation values from lowerBound to upperBound into the result buffer.
     /// - Parameters:
     ///   - lowerBound: Start value
     ///   - upperBound: End value
     ///   - result: Result buffer
-    static func arange<N: NumericType>(lowerBound: N, upperBound: N, result: ShapedBuffer<N, Device>)
+    static func arange<N: NumericType>(lowerBound: N, upperBound: N, result: MutableShapedBuffer<N, Device>)
     
     //MARK: Convolution Helpers
     
@@ -567,7 +565,7 @@ public protocol EngineType {
     ///   - kernelHeight: Height of the convolution kernel
     ///   - padding: Zero padding applied around the input image
     ///   - stride: Stride, with which the window is moved over the input image
-    static func img2col<N: NumericType>(values: ShapedBuffer<N, Device>, result: ShapedBuffer<N, Device>, kernelWidth: Int, kernelHeight: Int, padding: Int, stride: Int)
+    static func img2col<N: NumericType>(values: ShapedBuffer<N, Device>, result: MutableShapedBuffer<N, Device>, kernelWidth: Int, kernelHeight: Int, padding: Int, stride: Int)
     
     /// Performs an col2img transformation that aggregates all windows from a convolution matrix into an image tensor.
     /// - Parameters:
@@ -577,5 +575,5 @@ public protocol EngineType {
     ///   - kernelHeight: Height of the convolution kernel
     ///   - padding: Zero padding applied around the input image
     ///   - stride: Stride, with which the window is moved over the input image
-    static func col2img<N: NumericType>(matrix: ShapedBuffer<N, Device>, image: ShapedBuffer<N, Device>, kernelWidth: Int, kernelHeight: Int, padding: Int, stride: Int)
+    static func col2img<N: NumericType>(matrix: ShapedBuffer<N, Device>, image: MutableShapedBuffer<N, Device>, kernelWidth: Int, kernelHeight: Int, padding: Int, stride: Int)
 }

--- a/Sources/DL4S/NN/Layer/BasicRNN.swift
+++ b/Sources/DL4S/NN/Layer/BasicRNN.swift
@@ -59,10 +59,23 @@ public struct BasicRNN<Element: RandomizableType, Device: DeviceType>: RNN, Coda
     ///  - inputSize: Number of elements in each input vector of the RNN. The RNN expects inputs to have a shape of [sequence length, batch size, input size].
     ///  - hiddenSize: Number of elements in each output vector of the RNN.
     public init(inputSize: Int, hiddenSize: Int, direction: RNNDirection = .forward) {
+        var generator = WyHash()
+        self.init(inputSize: inputSize, hiddenSize: hiddenSize, direction: direction, using: &generator)
+    }
+    
+    /// A 'vanilla' RNN.
+    /// In each step, the RNN performs the transformation matMul(x\_t, W) + matMul(h\_t-1, U) + b.
+    ///
+    /// - Parameters:
+    ///  - inputSize: Number of elements in each input vector of the RNN. The RNN expects inputs to have a shape of [sequence length, batch size, input size].
+    ///  - hiddenSize: Number of elements in each output vector of the RNN.
+    ///  - direction: Direction, in which the RNN consumes the input sequence.
+    ///  - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputSize: Int, hiddenSize: Int, direction: RNNDirection = .forward, using generator: inout Generator) {
         self.direction = direction
         
-        W = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true)
-        U = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true)
+        W = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true, using: &generator)
+        U = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true, using: &generator)
         b = Tensor(repeating: 0, shape: [hiddenSize], requiresGradient: true)
     }
     

--- a/Sources/DL4S/NN/Layer/Convolution.swift
+++ b/Sources/DL4S/NN/Layer/Convolution.swift
@@ -58,11 +58,28 @@ public struct Convolution2D<Element: RandomizableType, Device: DeviceType>: Laye
     ///   - padding: Padding, that will be applied around the edges of the input
     ///   - stride: Stride, with which the convolution kernel is moved over the input tensor, >= 1.
     public init(inputChannels: Int, outputChannels: Int, kernelSize: (width: Int, height: Int), padding: Int? = nil, stride: Int = 1) {
+        var generator = WyHash()
+        self.init(inputChannels: inputChannels, outputChannels: outputChannels, kernelSize: kernelSize, padding: padding, stride: stride, using: &generator)
+    }
+    
+    /// Creates a 2D convolutional layer. 
+    ///
+    /// The inputs of the layer must have a shape [batchSize, channels, height, width]
+    ///
+    /// - Parameters:
+    ///   - inputChannels: Number of channels in the input
+    ///   - outputChannels: Number of channels in the output
+    ///   - kernelSize: Width and height of the convolution kernel
+    ///   - padding: Padding, that will be applied around the edges of the input
+    ///   - stride: Stride, with which the convolution kernel is moved over the input tensor, >= 1.
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputChannels: Int, outputChannels: Int, kernelSize: (width: Int, height: Int), padding: Int? = nil, stride: Int = 1, using generator: inout Generator) {
         self.filters = Tensor(
             normalDistributedWithShape: [outputChannels, inputChannels, kernelSize.height, kernelSize.width],
             mean: 0,
             stdev: 2 / Element(kernelSize.height * kernelSize.width * inputChannels).sqrt(),
-            requiresGradient: true
+            requiresGradient: true,
+            using: &generator
         )
         self.bias = Tensor(repeating: 0, shape: [1, outputChannels, 1, 1], requiresGradient: true)
         self.stride = stride
@@ -117,11 +134,28 @@ public struct TransposedConvolution2D<Element: RandomizableType, Device: DeviceT
     ///   - inset: Number of elements that are removed from the edges of the output.
     ///   - stride: Inverse of stride, with which the convolution kernel is moved over the input tensor, >= 1.
     public init(inputChannels: Int, outputChannels: Int, kernelSize: (width: Int, height: Int), inset: Int? = nil, stride: Int = 1) {
+        var generator = WyHash()
+        self.init(inputChannels: inputChannels, outputChannels: outputChannels, kernelSize: kernelSize, inset: inset, stride: stride, using: &generator)
+    }
+    
+    /// Creates a 2D transposed (fractionally strided) convolutional layer. The filter weights come from the given generator.
+    ///
+    /// The inputs of the layer must have a shape [batchSize, channels, height, width]
+    ///
+    /// - Parameters:
+    ///   - inputChannels: Number of channels in the input
+    ///   - outputChannels: Number of channels in the output
+    ///   - kernelSize: Width and height of the convolution kernel
+    ///   - inset: Number of elements that are removed from the edges of the output.
+    ///   - stride: Inverse of stride, with which the convolution kernel is moved over the input tensor, >= 1.
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputChannels: Int, outputChannels: Int, kernelSize: (width: Int, height: Int), inset: Int? = nil, stride: Int = 1, using generator: inout Generator) {
         self.filters = Tensor(
             normalDistributedWithShape: [outputChannels, inputChannels, kernelSize.height, kernelSize.width],
             mean: 0,
             stdev: 2 / Element(kernelSize.height * kernelSize.width * inputChannels).sqrt(),
-            requiresGradient: true
+            requiresGradient: true,
+            using: &generator
         )
         self.bias = Tensor(repeating: 0, shape: [1, outputChannels, 1, 1], requiresGradient: true)
         self.stride = stride

--- a/Sources/DL4S/NN/Layer/Dense.swift
+++ b/Sources/DL4S/NN/Layer/Dense.swift
@@ -52,7 +52,20 @@ public struct Dense<Element: RandomizableType, Device: DeviceType>: LayerType, C
     ///   - inputSize: Number of elements in an input vector
     ///   - outputSize: Number of elements in an output vector
     public init(inputSize: Int, outputSize: Int) {
-        weights = Tensor(xavierNormalWithShape: [inputSize, outputSize], requiresGradient: true)
+        var generator = WyHash()
+        self.init(inputSize: inputSize, outputSize: outputSize, using: &generator)
+    }
+    
+    /// Creates a dense / linear / fully connected layer with no output activation function.
+    ///
+    /// The layer expects inputs to have a shape of [batchSize, inputSize].
+    ///
+    /// - Parameters:
+    ///   - inputSize: Number of elements in an input vector
+    ///   - outputSize: Number of elements in an output vector
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputSize: Int, outputSize: Int, using generator: inout Generator) {
+        weights = Tensor(xavierNormalWithShape: [inputSize, outputSize], requiresGradient: true, using: &generator)
         bias = Tensor(repeating: 0, shape: [outputSize], requiresGradient: true)
         
         #if DEBUG

--- a/Sources/DL4S/NN/Layer/Embedding.swift
+++ b/Sources/DL4S/NN/Layer/Embedding.swift
@@ -60,7 +60,21 @@ public struct Embedding<Element: RandomizableType, Device: DeviceType>: LayerTyp
     ///   - outputSize: Embedding dimensionality.
     ///   - ignoreIndex: Token index that is ignored when retreiving values from the embedding matrix
     public init(inputFeatures: Int, outputSize: Int, ignoreIndex: Int = -1) {
-        self.embeddingMatrix = Tensor<Element, Device>(xavierNormalWithShape: [inputFeatures, outputSize], requiresGradient: true)
+        var generator = WyHash()
+        self.init(inputFeatures: inputFeatures, outputSize: outputSize, ignoreIndex: ignoreIndex, using: &generator)
+    }
+    
+    /// Creates an embedding layer that has an input vocabulary of size `inputFeatures` and returns embeddings with the size `outputSize`.
+    ///
+    /// The layer expects categorial inputs with a shape of [batch size] and returns embeddings with a shape of [batch size, outputSize]
+    ///
+    /// - Parameters:
+    ///   - inputFeatures: Vocabulary size.
+    ///   - outputSize: Embedding dimensionality.
+    ///   - ignoreIndex: Token index that is ignored when retreiving values from the embedding matrix
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputFeatures: Int, outputSize: Int, ignoreIndex: Int = -1, using generator: inout Generator) {
+        self.embeddingMatrix = Tensor<Element, Device>(xavierNormalWithShape: [inputFeatures, outputSize], requiresGradient: true, using: &generator)
         #if DEBUG
         self.embeddingMatrix.tag = "W"
         #endif

--- a/Sources/DL4S/NN/Layer/GRU.swift
+++ b/Sources/DL4S/NN/Layer/GRU.swift
@@ -70,14 +70,28 @@ public struct GRU<Element: RandomizableType, Device: DeviceType>: RNN, Codable {
     ///   - hiddenSize: Number of elements at each timestep in the output
     ///   - direction: Direction, in which the RNN consumes the input sequence.
     public init(inputSize: Int, hiddenSize: Int, direction: RNNDirection = .forward) {
+        var generator = WyHash()
+        self.init(inputSize: inputSize, hiddenSize: hiddenSize, direction: direction, using: &generator)
+    }
+    
+    /// Creates a Gated Recurrent Unit layer.
+    ///
+    /// The RNN expects inputs to have a shape of [sequence length, batch size, input size].
+    ///
+    /// - Parameters:
+    ///   - inputSize: Number of elements at each timestep of the input
+    ///   - hiddenSize: Number of elements at each timestep in the output
+    ///   - direction: Direction, in which the RNN consumes the input sequence.
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputSize: Int, hiddenSize: Int, direction: RNNDirection = .forward, using generator: inout Generator) {
         self.direction = direction
         
-        Wz = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true)
-        Wr = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true)
-        Wh = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true)
-        Uz = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true)
-        Ur = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true)
-        Uh = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true)
+        Wz = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true, using: &generator)
+        Wr = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true, using: &generator)
+        Wh = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true, using: &generator)
+        Uz = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true, using: &generator)
+        Ur = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true, using: &generator)
+        Uh = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true, using: &generator)
         bz = Tensor(repeating: 0, shape: [hiddenSize], requiresGradient: true)
         br = Tensor(repeating: 0, shape: [hiddenSize], requiresGradient: true)
         bh = Tensor(repeating: 0, shape: [hiddenSize], requiresGradient: true)

--- a/Sources/DL4S/NN/Layer/LSTM.swift
+++ b/Sources/DL4S/NN/Layer/LSTM.swift
@@ -72,16 +72,30 @@ public struct LSTM<Element: RandomizableType, Device: DeviceType>: RNN, Codable 
     ///   - hiddenSize: Number of elements at each timestep in the output
     ///   - direction: Direction, in which the RNN consumes the input sequence.
     public init(inputSize: Int, hiddenSize: Int, direction: RNNDirection = .forward) {
+        var generator = WyHash()
+        self.init(inputSize: inputSize, hiddenSize: hiddenSize, direction: direction, using: &generator)
+    }
+    
+    /// Creates a Long Short-Term Memory (LSTM) layer.
+    ///
+    /// The RNN expects inputs to have a shape of [sequence length, batch size, input size].
+    ///
+    /// - Parameters:
+    ///   - inputSize: Number of elements at each timestep of the input
+    ///   - hiddenSize: Number of elements at each timestep in the output
+    ///   - direction: Direction, in which the RNN consumes the input sequence.
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputSize: Int, hiddenSize: Int, direction: RNNDirection = .forward, using generator: inout Generator) {
         self.direction = direction
         
-        Wi = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true)
-        Wo = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true)
-        Wf = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true)
-        Wc = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true)
-        Ui = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true)
-        Uo = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true)
-        Uf = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true)
-        Uc = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true)
+        Wi = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true, using: &generator)
+        Wo = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true, using: &generator)
+        Wf = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true, using: &generator)
+        Wc = Tensor(normalDistributedWithShape: [inputSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(inputSize)).sqrt(), requiresGradient: true, using: &generator)
+        Ui = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true, using: &generator)
+        Uo = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true, using: &generator)
+        Uf = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true, using: &generator)
+        Uc = Tensor(normalDistributedWithShape: [hiddenSize, hiddenSize], mean: 0, stdev: (Element(1) / Element(hiddenSize)).sqrt(), requiresGradient: true, using: &generator)
         bi = Tensor(repeating: 0, shape: [hiddenSize], requiresGradient: true)
         bo = Tensor(repeating: 0, shape: [hiddenSize], requiresGradient: true)
         bf = Tensor(repeating: 0, shape: [hiddenSize], requiresGradient: true)

--- a/Sources/DL4S/NN/Layer/Layer.swift
+++ b/Sources/DL4S/NN/Layer/Layer.swift
@@ -27,7 +27,7 @@ import Foundation
 
 /// A layer of a neural network that performs an arbitrary transformation on its inputs to generate its outputs.
 /// The layer may have parameters, which influence, how the outputs are generated.
-public protocol LayerType {
+public protocol LayerType<Inputs, Outputs, Parameter, Device> {
     /// Inputs of the layer
     associatedtype Inputs
     
@@ -55,44 +55,3 @@ public protocol LayerType {
     func callAsFunction(_ inputs: Inputs) -> Outputs
 }
 
-
-/// Type erased layer
-public struct AnyLayer<Inputs, Outputs, Parameter: NumericType, Device: DeviceType>: LayerType {
-    public var parameterPaths: [WritableKeyPath<Self, Tensor<Parameter, Device>>] {
-        parameters.indices.map {
-            \Self.parameters[$0]
-        }
-    }
-    
-    public var parameters: [Tensor<Parameter, Device>] {
-        get { getParameters() }
-        set { setParameters(newValue) }
-    }
-    
-    private var getParameters: () -> [Tensor<Parameter, Device>]
-    private var setParameters: ([Tensor<Parameter, Device>]) -> ()
-    private var forward: (Inputs) -> Outputs
-    
-    /// Creates a layer by type-erasing the given layer
-    /// - Parameter wrappedLayer: Layer to wrap.
-    public init<L: LayerType>(_ wrappedLayer: L) where L.Inputs == Inputs, L.Outputs == Outputs, L.Parameter == Parameter, L.Device == Device {
-        var wrappedLayer = wrappedLayer
-        let paths = wrappedLayer.parameterPaths
-        
-        getParameters = {
-            wrappedLayer.parameters
-        }
-        setParameters = {
-            zip(paths, $0).forEach {
-                wrappedLayer[keyPath: $0] = $1
-            }
-        }
-        forward = {
-            wrappedLayer.callAsFunction($0)
-        }
-    }
-    
-    public func callAsFunction(_ inputs: Inputs) -> Outputs {
-        forward(inputs)
-    }
-}

--- a/Sources/DL4S/NN/Layer/LayerNorm.swift
+++ b/Sources/DL4S/NN/Layer/LayerNorm.swift
@@ -25,7 +25,10 @@
 
 import Foundation
 
-/// A layer that normalizes its inputs along all dimensions except the batch dimension
+/// A layer that normalizes its inputs along the trailing dimensions given by `inputSize`.
+///
+/// Every leading dimension of the input is treated as an independent sample. With `inputSize: [hidden]`,
+/// a `[batch, sequence, hidden]` input is normalized per sequence element.
 public struct LayerNorm<Element: RandomizableType, Device: DeviceType>: LayerType, Codable {
     public var parameterPaths: [WritableKeyPath<LayerNorm<Element, Device>, Tensor<Element, Device>>] {
         [\.shift, \.scale]
@@ -33,44 +36,39 @@ public struct LayerNorm<Element: RandomizableType, Device: DeviceType>: LayerTyp
     public var parameters: [Tensor<Element, Device>] {
         get {[shift, scale]}
     }
-    
-    /// Whether the layer is training, currently ignored.
-    public var isTraining = true
-    
+
     /// Learned shift vector
     public var shift: Tensor<Element, Device>
-    
+
     /// Learned scale vector
     public var scale: Tensor<Element, Device>
-    
-    /// Momentum with which to update mean and variance. Currently ignored
-    public var momentum: Element
 
-    /// A layer that normalizes its inputs along all dimensions except the batch dimension
-    public init(inputSize: [Int], momentum: Element = Element(0.9)) {
+    /// A layer that normalizes its inputs along the trailing dimensions given by `inputSize`.
+    /// - Parameter inputSize: Shape of the normalized trailing dimensions of the input.
+    public init(inputSize: [Int]) {
         shift = Tensor(repeating: 0, shape: inputSize, requiresGradient: true)
         scale = Tensor(repeating: 1, shape: inputSize, requiresGradient: true)
-        
-        self.momentum = momentum
-        
+
         #if DEBUG
         shift.tag = "shift"
         scale.tag = "scale"
         #endif
     }
-    
+
     public func callAsFunction(_ inputs: Tensor<Element, Device>) -> Tensor<Element, Device> {
         OperationGroup.capture(named: "LayerNorm") {
             let x = inputs
-            let axes = Array(1 ..< x.dim)
+            let sampleDim = x.dim - shift.dim
+            let axes = Array(sampleDim ..< x.dim)
+            let statisticsShape = Array(x.shape.prefix(sampleDim)) + Array(repeating: 1, count: shift.dim)
             let mean = x
                 .reduceMean(along: axes)
-                .view(as: [x.shape[0]] + Array(repeating: 1, count: axes.count))
-            
+                .view(as: statisticsShape)
+
             let variance = x
                 .variance(along: axes)
-                .view(as: mean.shape)
-            
+                .view(as: statisticsShape)
+
             let normalized = (x - mean) / (sqrt(variance) + 1e-5)
             return normalized * scale + shift
         }

--- a/Sources/DL4S/NN/Layer/Residual.swift
+++ b/Sources/DL4S/NN/Layer/Residual.swift
@@ -62,8 +62,19 @@ public struct ResidualBlock<Element: RandomizableType, Device: DeviceType>: Laye
     public var downsample: Sequential<Convolution2D<Element, Device>, BatchNorm<Element, Device>>?
     
     public init(inputShape: [Int], outPlanes: Int, downsample: Int) {
-        conv1 = Convolution2D(inputChannels: inputShape[0], outputChannels: outPlanes, kernelSize: (3, 3), stride: downsample)
-        conv2 = Convolution2D(inputChannels: outPlanes, outputChannels: outPlanes, kernelSize: (3, 3))
+        var generator = WyHash()
+        self.init(inputShape: inputShape, outPlanes: outPlanes, downsample: downsample, using: &generator)
+    }
+
+    /// Creates a residual block with two convolutions. 
+    /// - Parameters:
+    ///   - inputShape: Shape of the input without the batch dimension, [channels, height, width]
+    ///   - outPlanes: Number of output channels
+    ///   - downsample: Stride of the first convolution. A value other than 1 adds a downsampling shortcut.
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputShape: [Int], outPlanes: Int, downsample: Int, using generator: inout Generator) {
+        conv1 = Convolution2D(inputChannels: inputShape[0], outputChannels: outPlanes, kernelSize: (3, 3), stride: downsample, using: &generator)
+        conv2 = Convolution2D(inputChannels: outPlanes, outputChannels: outPlanes, kernelSize: (3, 3), using: &generator)
         
         let convShape = ConvUtil.outputShape(for: inputShape, kernelCount: outPlanes, kernelWidth: 3, kernelHeight: 3, stride: downsample, padding: 1)
         
@@ -72,7 +83,7 @@ public struct ResidualBlock<Element: RandomizableType, Device: DeviceType>: Laye
         
         if downsample != 1 {
             self.downsample = Sequential {
-                Convolution2D<Element, Device>(inputChannels: inputShape[0], outputChannels: outPlanes, kernelSize: (1, 1), padding: 0, stride: downsample)
+                Convolution2D<Element, Device>(inputChannels: inputShape[0], outputChannels: outPlanes, kernelSize: (1, 1), padding: 0, stride: downsample, using: &generator)
                 BatchNorm<Element, Device>(inputSize: [outPlanes, inputShape[1] / downsample, inputShape[2] / downsample])
             }
         } else {

--- a/Sources/DL4S/NN/Models/AlexNet.swift
+++ b/Sources/DL4S/NN/Models/AlexNet.swift
@@ -74,24 +74,38 @@ public struct AlexNet<Element: RandomizableType, Device: DeviceType>: LayerType,
     ///   - inputChannels: Number of input channesls. Data forwarded through the network must have [batchSize, inputChannels, height, depth] shape.
     ///   - classes: Number of classes / dimensionality of network output
     public init(inputChannels: Int, classes: Int) {
+        var generator = WyHash()
+        self.init(inputChannels: inputChannels, classes: classes, using: &generator)
+    }
+
+    /// Creates an AlexNet image classification network with the given number of input channels and classes.
+    ///
+    /// The network expects images with a resolution of 192x192 or higher.
+    ///
+    /// https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf
+    /// - Parameters:
+    ///   - inputChannels: Number of input channesls. Data forwarded through the network must have [batchSize, inputChannels, height, depth] shape.
+    ///   - classes: Number of classes / dimensionality of network output
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputChannels: Int, classes: Int, using generator: inout Generator) {
         featureNet = Sequential {
-            Convolution2D<Element, Device>(inputChannels: inputChannels, outputChannels: 64, kernelSize: (11, 11), padding: 2, stride: 4)
+            Convolution2D<Element, Device>(inputChannels: inputChannels, outputChannels: 64, kernelSize: (11, 11), padding: 2, stride: 4, using: &generator)
             Relu<Element, Device>()
             MaxPool2D<Element, Device>(windowSize: 3, stride: 2)
             
-            Convolution2D<Element, Device>(inputChannels: 64, outputChannels: 192, kernelSize: (5, 5), padding: 2, stride: 1)
+            Convolution2D<Element, Device>(inputChannels: 64, outputChannels: 192, kernelSize: (5, 5), padding: 2, stride: 1, using: &generator)
             BatchNorm<Element, Device>(inputSize: [192, 1, 1])
             Relu<Element, Device>()
             MaxPool2D<Element, Device>(windowSize: 3, stride: 2)
             
-            Convolution2D<Element, Device>(inputChannels: 192, outputChannels: 384, kernelSize: (3, 3), padding: 1, stride: 1)
+            Convolution2D<Element, Device>(inputChannels: 192, outputChannels: 384, kernelSize: (3, 3), padding: 1, stride: 1, using: &generator)
             Relu<Element, Device>()
             
-            Convolution2D<Element, Device>(inputChannels: 384, outputChannels: 256, kernelSize: (3, 3), padding: 1, stride: 1)
+            Convolution2D<Element, Device>(inputChannels: 384, outputChannels: 256, kernelSize: (3, 3), padding: 1, stride: 1, using: &generator)
             BatchNorm<Element, Device>(inputSize: [256, 1, 1])
             Relu<Element, Device>()
             
-            Convolution2D<Element, Device>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3), padding: 1, stride: 1)
+            Convolution2D<Element, Device>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3), padding: 1, stride: 1, using: &generator)
             BatchNorm<Element, Device>(inputSize: [256, 1, 1])
             Relu<Element, Device>()
             MaxPool2D<Element, Device>(windowSize: 3, stride: 2)
@@ -103,16 +117,16 @@ public struct AlexNet<Element: RandomizableType, Device: DeviceType>: LayerType,
             Flatten<Element, Device>()
             
             Dropout<Element, Device>(rate: Float(0.5))
-            Dense<Element, Device>(inputSize: 256 * 6 * 6, outputSize: 4096)
+            Dense<Element, Device>(inputSize: 256 * 6 * 6, outputSize: 4096, using: &generator)
             BatchNorm<Element, Device>(inputSize: [4096])
             Relu<Element, Device>()
             
             Dropout<Element, Device>(rate: Float(0.5))
-            Dense<Element, Device>(inputSize: 4096, outputSize: 4096)
+            Dense<Element, Device>(inputSize: 4096, outputSize: 4096, using: &generator)
             BatchNorm<Element, Device>(inputSize: [4096])
             Relu<Element, Device>()
             
-            Dense<Element, Device>(inputSize: 4096, outputSize: classes)
+            Dense<Element, Device>(inputSize: 4096, outputSize: classes, using: &generator)
             LogSoftmax<Element, Device>()
         }
     }

--- a/Sources/DL4S/NN/Models/ResNet.swift
+++ b/Sources/DL4S/NN/Models/ResNet.swift
@@ -66,38 +66,48 @@ public struct ResNet18<Element: RandomizableType, Device: DeviceType>: LayerType
     public var classifier: Sequential<Sequential<AdaptiveAvgPool2D<Element, Device>, Flatten<Element, Device>>, Sequential<Dense<Element, Device>, LogSoftmax<Element, Device>>>
     
     public init(inputShape: [Int], classes: Int) {
+        var generator = WyHash()
+        self.init(inputShape: inputShape, classes: classes, using: &generator)
+    }
+
+    /// Creates a ResNet18 image classification network.
+    /// - Parameters:
+    ///   - inputShape: Shape of the input without the batch dimension, [channels, height, width]
+    ///   - classes: Number of classes / dimensionality of network output
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputShape: [Int], classes: Int, using generator: inout Generator) {
         let startOut = ConvUtil.outputShape(for: inputShape, kernelCount: 64, kernelWidth: 7, kernelHeight: 7, stride: 2, padding: 3)
         
         start = Sequential {
-            Convolution2D<Element, Device>(inputChannels: inputShape[0], outputChannels: 64, kernelSize: (7, 7), padding: 3, stride: 2)
+            Convolution2D<Element, Device>(inputChannels: inputShape[0], outputChannels: 64, kernelSize: (7, 7), padding: 3, stride: 2, using: &generator)
             BatchNorm<Element, Device>(inputSize: startOut)
             Relu<Element, Device>()
         }
         
         l1 = Sequential {
-            ResidualBlock<Element, Device>(inputShape: startOut, outPlanes: 64, downsample: 1)
-            ResidualBlock<Element, Device>(inputShape: startOut, outPlanes: 64, downsample: 1)
+            ResidualBlock<Element, Device>(inputShape: startOut, outPlanes: 64, downsample: 1, using: &generator)
+            ResidualBlock<Element, Device>(inputShape: startOut, outPlanes: 64, downsample: 1, using: &generator)
         }
         
         l2 = Sequential {
-            ResidualBlock<Element, Device>(inputShape: [64, startOut[1], startOut[2]], outPlanes: 128, downsample: 2)
-            ResidualBlock<Element, Device>(inputShape: [128, startOut[1] / 2, startOut[2] / 2], outPlanes: 128, downsample: 1)
+            ResidualBlock<Element, Device>(inputShape: [64, startOut[1], startOut[2]], outPlanes: 128, downsample: 2, using: &generator)
+            ResidualBlock<Element, Device>(inputShape: [128, startOut[1] / 2, startOut[2] / 2], outPlanes: 128, downsample: 1, using: &generator)
         }
         
         l3 = Sequential {
-            ResidualBlock<Element, Device>(inputShape: [128, startOut[1] / 2, startOut[2] / 2], outPlanes: 256, downsample: 2)
-            ResidualBlock<Element, Device>(inputShape: [256, startOut[1] / 4, startOut[2] / 4], outPlanes: 256, downsample: 1)
+            ResidualBlock<Element, Device>(inputShape: [128, startOut[1] / 2, startOut[2] / 2], outPlanes: 256, downsample: 2, using: &generator)
+            ResidualBlock<Element, Device>(inputShape: [256, startOut[1] / 4, startOut[2] / 4], outPlanes: 256, downsample: 1, using: &generator)
         }
         
         l4 = Sequential {
-            ResidualBlock<Element, Device>(inputShape: [256, startOut[1] / 4, startOut[2] / 4], outPlanes: 512, downsample: 2)
-            ResidualBlock<Element, Device>(inputShape: [512, startOut[1] / 8, startOut[2] / 8], outPlanes: 512, downsample: 1)
+            ResidualBlock<Element, Device>(inputShape: [256, startOut[1] / 4, startOut[2] / 4], outPlanes: 512, downsample: 2, using: &generator)
+            ResidualBlock<Element, Device>(inputShape: [512, startOut[1] / 8, startOut[2] / 8], outPlanes: 512, downsample: 1, using: &generator)
         }
         
         classifier = Sequential {
             AdaptiveAvgPool2D<Element, Device>(targetSize: 1)
             Flatten<Element, Device>()
-            Dense<Element, Device>(inputSize: 512, outputSize: classes)
+            Dense<Element, Device>(inputSize: 512, outputSize: classes, using: &generator)
             LogSoftmax<Element, Device>()
         }
     }

--- a/Sources/DL4S/NN/Models/Transformer/MultiHeadAttention.swift
+++ b/Sources/DL4S/NN/Models/Transformer/MultiHeadAttention.swift
@@ -66,16 +66,29 @@ public struct MultiHeadAttention<Element: RandomizableType, Device: DeviceType>:
     ///   - valueDim: Intermediate last dimension of values
     ///   - dropout: Dropout rate
     public init(heads: Int, hiddenDim: Int, keyDim: Int, valueDim: Int, dropout: Float = 0.1) {
+        var generator = WyHash()
+        self.init(heads: heads, hiddenDim: hiddenDim, keyDim: keyDim, valueDim: valueDim, dropout: dropout, using: &generator)
+    }
+    
+    /// Multi-Head Attention Layer following [Attention Is All You Need](https://arxiv.org/pdf/1706.03762.pdf).
+    /// - Parameters:
+    ///   - heads: Number of attention heads
+    ///   - hiddenDim: Last dimension of keys, queries and values
+    ///   - keyDim: Last dimesion of keys
+    ///   - valueDim: Intermediate last dimension of values
+    ///   - dropout: Dropout rate
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(heads: Int, hiddenDim: Int, keyDim: Int, valueDim: Int, dropout: Float = 0.1, using generator: inout Generator) {
         self.heads = heads
         self.keyDim = keyDim
         self.valueDim = valueDim
         self.hiddenDim = hiddenDim
         
         attn = ScaledDotProductAttention(temperature: Element(keyDim).sqrt())
-        qDense = Tensor(xavierNormalWithShape: hiddenDim, keyDim * heads, requiresGradient: true)
-        kDense = Tensor(xavierNormalWithShape: hiddenDim, keyDim * heads, requiresGradient: true)
-        vDense = Tensor(xavierNormalWithShape: hiddenDim, valueDim * heads, requiresGradient: true)
-        fc = Tensor(xavierNormalWithShape: valueDim * heads, hiddenDim, requiresGradient: true)
+        qDense = Tensor(xavierNormalWithShape: [hiddenDim, keyDim * heads], requiresGradient: true, using: &generator)
+        kDense = Tensor(xavierNormalWithShape: [hiddenDim, keyDim * heads], requiresGradient: true, using: &generator)
+        vDense = Tensor(xavierNormalWithShape: [hiddenDim, valueDim * heads], requiresGradient: true, using: &generator)
+        fc = Tensor(xavierNormalWithShape: [valueDim * heads, hiddenDim], requiresGradient: true, using: &generator)
         self.dropout = Dropout(rate: dropout)
         norm = LayerNorm(inputSize: [hiddenDim])
         

--- a/Sources/DL4S/NN/Models/Transformer/PointwiseFeedForward.swift
+++ b/Sources/DL4S/NN/Models/Transformer/PointwiseFeedForward.swift
@@ -55,8 +55,21 @@ public struct PointwiseFeedForward<Element: RandomizableType, Device: DeviceType
     ///   - hiddenSize: Hidden size between dense layers of the block
     ///   - dropoutRate: Rate, with which dropout is applied between activation and the second dense layer. Can be enabled and disabled using `isDropoutActive`.
     public init(size: Int, hiddenSize: Int, dropoutRate: Float) {
-        dense1 = Dense(inputSize: size, outputSize: hiddenSize)
-        dense2 = Dense(inputSize: hiddenSize, outputSize: size)
+        var generator = WyHash()
+        self.init(size: size, hiddenSize: hiddenSize, dropoutRate: dropoutRate, using: &generator)
+    }
+    
+    /// Creates a pointwise forward layer to be used in a transformer as introduced in [Attention Is All You Need](https://arxiv.org/pdf/1706.03762.pdf).
+    /// The block sequences a dense layer, gelu activation, another dense layer, dropout, a residual connection and layer normalization.
+    ///
+    /// - Parameters:
+    ///   - size: Size of last dimension of inputs and outputs of the block
+    ///   - hiddenSize: Hidden size between dense layers of the block
+    ///   - dropoutRate: Rate, with which dropout is applied between activation and the second dense layer. Can be enabled and disabled using `isDropoutActive`.
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(size: Int, hiddenSize: Int, dropoutRate: Float, using generator: inout Generator) {
+        dense1 = Dense(inputSize: size, outputSize: hiddenSize, using: &generator)
+        dense2 = Dense(inputSize: hiddenSize, outputSize: size, using: &generator)
         norm = LayerNorm(inputSize: [size])
         dropout = Dropout(rate: dropoutRate)
     }

--- a/Sources/DL4S/NN/Models/Transformer/Transformer.swift
+++ b/Sources/DL4S/NN/Models/Transformer/Transformer.swift
@@ -67,11 +67,28 @@ public struct Transformer<Element: RandomizableType, Device: DeviceType>: LayerT
     ///   - forwardDim: Size of activations in poitnwise feed forward layers
     ///   - dropout: Dropout rate
     public init(encoderLayers: Int, decoderLayers: Int, vocabSize: Int, hiddenDim: Int, heads: Int, keyDim: Int, valueDim: Int, forwardDim: Int, dropout: Float = 0.1) {
-        embedding = Embedding(inputFeatures: vocabSize, outputSize: hiddenDim, ignoreIndex: -1)
+        var generator = WyHash()
+        self.init(encoderLayers: encoderLayers, decoderLayers: decoderLayers, vocabSize: vocabSize, hiddenDim: hiddenDim, heads: heads, keyDim: keyDim, valueDim: valueDim, forwardDim: forwardDim, dropout: dropout, using: &generator)
+    }
+    
+    /// Creates a new transformer, which follows [Attention Is All You Need](https://arxiv.org/pdf/1706.03762.pdf).
+    /// - Parameters:
+    ///   - encoderLayers: Number of encoder layers
+    ///   - decoderLayers: Number of decoder layers
+    ///   - vocabSize: Number of tokens in the vocabulary of the transformer
+    ///   - hiddenDim: Size of transformer layer outputs
+    ///   - heads: Number of attention heads in multi-head attention layers
+    ///   - keyDim: Size of key vectors in multi-head attention layers
+    ///   - valueDim: Size of value vectors in muti-head attention layers
+    ///   - forwardDim: Size of activations in poitnwise feed forward layers
+    ///   - dropout: Dropout rate
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(encoderLayers: Int, decoderLayers: Int, vocabSize: Int, hiddenDim: Int, heads: Int, keyDim: Int, valueDim: Int, forwardDim: Int, dropout: Float = 0.1, using generator: inout Generator) {
+        embedding = Embedding(inputFeatures: vocabSize, outputSize: hiddenDim, ignoreIndex: -1, using: &generator)
         self.dropout = Dropout(rate: dropout)
         positionalEncoding = PositionalEncoding(hiddenSize: hiddenDim)
-        encoder = TransformerEncoder(layerCount: encoderLayers, heads: heads, keyDim: keyDim, valueDim: valueDim, modelDim: hiddenDim, forwardDim: forwardDim, dropout: dropout)
-        decoder = TransformerDecoder(layerCount: decoderLayers, heads: heads, keyDim: keyDim, valueDim: valueDim, modelDim: hiddenDim, forwardDim: forwardDim, dropout: dropout)
+        encoder = TransformerEncoder(layerCount: encoderLayers, heads: heads, keyDim: keyDim, valueDim: valueDim, modelDim: hiddenDim, forwardDim: forwardDim, dropout: dropout, using: &generator)
+        decoder = TransformerDecoder(layerCount: decoderLayers, heads: heads, keyDim: keyDim, valueDim: valueDim, modelDim: hiddenDim, forwardDim: forwardDim, dropout: dropout, using: &generator)
         outputBias = Tensor(repeating: 0, shape: [vocabSize], requiresGradient: true)
         
         #if DEBUG

--- a/Sources/DL4S/NN/Models/Transformer/TransformerDecoder.swift
+++ b/Sources/DL4S/NN/Models/Transformer/TransformerDecoder.swift
@@ -41,8 +41,15 @@ public struct TransformerDecoder<Element: RandomizableType, Device: DeviceType>:
     
     /// Creates aransformer encoder sequencing positional encoding and token embedding and multiple transformer encoder layers, as introduced by [Attention Is All You Need](https://arxiv.org/pdf/1706.03762.pdf).
     public init(layerCount: Int, heads: Int, keyDim: Int, valueDim: Int, modelDim: Int, forwardDim: Int, dropout: Float) {
+        var generator = WyHash()
+        self.init(layerCount: layerCount, heads: heads, keyDim: keyDim, valueDim: valueDim, modelDim: modelDim, forwardDim: forwardDim, dropout: dropout, using: &generator)
+    }
+
+    /// Creates aransformer encoder sequencing positional encoding and token embedding and multiple transformer encoder layers, as introduced by [Attention Is All You Need](https://arxiv.org/pdf/1706.03762.pdf).
+    /// - Parameter generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(layerCount: Int, heads: Int, keyDim: Int, valueDim: Int, modelDim: Int, forwardDim: Int, dropout: Float, using generator: inout Generator) {
         decoderLayers = (0 ..< layerCount).map { _ in
-            TransformerDecoderBlock(hiddenDim: modelDim, forwardDim: forwardDim, heads: heads, keyDim: keyDim, valueDim: valueDim, dropout: dropout)
+            TransformerDecoderBlock(hiddenDim: modelDim, forwardDim: forwardDim, heads: heads, keyDim: keyDim, valueDim: valueDim, dropout: dropout, using: &generator)
         }
     }
     

--- a/Sources/DL4S/NN/Models/Transformer/TransformerDecoderBlock.swift
+++ b/Sources/DL4S/NN/Models/Transformer/TransformerDecoderBlock.swift
@@ -50,9 +50,23 @@ public struct TransformerDecoderBlock<Element: RandomizableType, Device: DeviceT
     ///   - valueDim: Size of value vectors within multi-head attention layer
     ///   - dropout: Dropout rate for dropout applied within self-attention and pointwise feed forward layer
     public init(hiddenDim: Int, forwardDim: Int, heads: Int, keyDim: Int, valueDim: Int, dropout: Float = 0.1) {
-        selfAttention = MultiHeadAttention(heads: heads, hiddenDim: hiddenDim, keyDim: keyDim, valueDim: valueDim, dropout: dropout)
-        encoderAttention = MultiHeadAttention(heads: heads, hiddenDim: hiddenDim, keyDim: keyDim, valueDim: valueDim, dropout: dropout)
-        pointwiseFeedForward = PointwiseFeedForward(size: hiddenDim, hiddenSize: forwardDim, dropoutRate: dropout)
+        var generator = WyHash()
+        self.init(hiddenDim: hiddenDim, forwardDim: forwardDim, heads: heads, keyDim: keyDim, valueDim: valueDim, dropout: dropout, using: &generator)
+    }
+
+    /// Creates Transformer encoder layer consisting of a self-attention and a pointwise feed forward layer as introduced by [Attention Is All You Need](https://arxiv.org/pdf/1706.03762.pdf).
+    /// - Parameters:
+    ///   - hiddenDim: Last dimension of inputs and outputs
+    ///   - forwardDim: Size of value vectors within pointwise feed forward layer
+    ///   - heads: Number of attention heads
+    ///   - keyDim: Size of key and query vectors within multi-head attention layer
+    ///   - valueDim: Size of value vectors within multi-head attention layer
+    ///   - dropout: Dropout rate for dropout applied within self-attention and pointwise feed forward layer
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(hiddenDim: Int, forwardDim: Int, heads: Int, keyDim: Int, valueDim: Int, dropout: Float = 0.1, using generator: inout Generator) {
+        selfAttention = MultiHeadAttention(heads: heads, hiddenDim: hiddenDim, keyDim: keyDim, valueDim: valueDim, dropout: dropout, using: &generator)
+        encoderAttention = MultiHeadAttention(heads: heads, hiddenDim: hiddenDim, keyDim: keyDim, valueDim: valueDim, dropout: dropout, using: &generator)
+        pointwiseFeedForward = PointwiseFeedForward(size: hiddenDim, hiddenSize: forwardDim, dropoutRate: dropout, using: &generator)
     }
     
     /// Applies multi-head self attention and a pointwise feed forward layer to the inputs

--- a/Sources/DL4S/NN/Models/Transformer/TransformerEncoder.swift
+++ b/Sources/DL4S/NN/Models/Transformer/TransformerEncoder.swift
@@ -50,8 +50,24 @@ public struct TransformerEncoder<Element: RandomizableType, Device: DeviceType>:
     ///   - forwardDim: Size of hidden layer activations within pointwise feed forward layers
     ///   - dropout: Rate of dropout applied within pointwise feed forward and multi-head attention layers
     public init(layerCount: Int, heads: Int, keyDim: Int, valueDim: Int, modelDim: Int, forwardDim: Int, dropout: Float) {
+        var generator = WyHash()
+        self.init(layerCount: layerCount, heads: heads, keyDim: keyDim, valueDim: valueDim, modelDim: modelDim, forwardDim: forwardDim, dropout: dropout, using: &generator)
+    }
+
+    /// Creates a transformer encoder sequencing positional encoding and token embedding and multiple transformer encoder layers, as introduced by [Attention Is All You Need](https://arxiv.org/pdf/1706.03762.pdf).
+    /// - Parameters:
+    ///   - vocabSize: Number of distinct tokens that can occur in input
+    ///   - layerCount: Number of transformer encoder layers
+    ///   - heads: Number of attention heads in each encoder layer
+    ///   - keyDim: Size of keys in multi-head attention layers
+    ///   - valueDim: Size of values in multi-head attention layers
+    ///   - modelDim: Size of embedding vectors as well as hidden layer activations and outputs
+    ///   - forwardDim: Size of hidden layer activations within pointwise feed forward layers
+    ///   - dropout: Rate of dropout applied within pointwise feed forward and multi-head attention layers
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(layerCount: Int, heads: Int, keyDim: Int, valueDim: Int, modelDim: Int, forwardDim: Int, dropout: Float, using generator: inout Generator) {
         encoderLayers = (0 ..< layerCount).map { i in
-            TransformerEncoderBlock(hiddenDim: modelDim, forwardDim: forwardDim, heads: heads, keyDim: keyDim, valueDim: valueDim, dropout: dropout)
+            TransformerEncoderBlock(hiddenDim: modelDim, forwardDim: forwardDim, heads: heads, keyDim: keyDim, valueDim: valueDim, dropout: dropout, using: &generator)
         }
     }
     

--- a/Sources/DL4S/NN/Models/Transformer/TransformerEncoderBlock.swift
+++ b/Sources/DL4S/NN/Models/Transformer/TransformerEncoderBlock.swift
@@ -48,8 +48,22 @@ public struct TransformerEncoderBlock<Element: RandomizableType, Device: DeviceT
     ///   - valueDim: Size of value vectors within multi-head attention layer
     ///   - dropout: Dropout rate for dropout applied within self-attention and pointwise feed forward layer
     public init(hiddenDim: Int, forwardDim: Int, heads: Int, keyDim: Int, valueDim: Int, dropout: Float = 0.1) {
-        selfAttention = MultiHeadAttention(heads: heads, hiddenDim: hiddenDim, keyDim: keyDim, valueDim: valueDim, dropout: dropout)
-        pointwiseFeedForward = PointwiseFeedForward(size: hiddenDim, hiddenSize: forwardDim, dropoutRate: dropout)
+        var generator = WyHash()
+        self.init(hiddenDim: hiddenDim, forwardDim: forwardDim, heads: heads, keyDim: keyDim, valueDim: valueDim, dropout: dropout, using: &generator)
+    }
+
+    /// Creates Transformer encoder layer consisting of a self-attention and a pointwise feed forward layer as introduced by [Attention Is All You Need](https://arxiv.org/pdf/1706.03762.pdf).
+    /// - Parameters:
+    ///   - hiddenDim: Last dimension of inputs and outputs
+    ///   - forwardDim: Size of value vectors within pointwise feed forward layer
+    ///   - heads: Number of attention heads
+    ///   - keyDim: Size of key and query vectors within multi-head attention layer
+    ///   - valueDim: Size of value vectors within multi-head attention layer
+    ///   - dropout: Dropout rate for dropout applied within self-attention and pointwise feed forward layer
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(hiddenDim: Int, forwardDim: Int, heads: Int, keyDim: Int, valueDim: Int, dropout: Float = 0.1, using generator: inout Generator) {
+        selfAttention = MultiHeadAttention(heads: heads, hiddenDim: hiddenDim, keyDim: keyDim, valueDim: valueDim, dropout: dropout, using: &generator)
+        pointwiseFeedForward = PointwiseFeedForward(size: hiddenDim, hiddenSize: forwardDim, dropoutRate: dropout, using: &generator)
     }
     
     /// Applies multi-head self attention and a pointwise feed forward layer to the inputs

--- a/Sources/DL4S/NN/Models/VGG/VGG.swift
+++ b/Sources/DL4S/NN/Models/VGG/VGG.swift
@@ -88,18 +88,27 @@ public extension VGGBase {
     }
     
     static func makeDense(classes: Int) -> DenseLayer {
+        var generator = WyHash()
+        return makeDense(classes: classes, using: &generator)
+    }
+
+    /// Creates the dense classifier that follows the convolutional blocks. 
+    /// - Parameters:
+    ///   - classes: Number of classes / dimensionality of network output
+    ///   - generator: Random number generator that provides the initial weights.
+    static func makeDense<Generator: RandomNumberGenerator>(classes: Int, using generator: inout Generator) -> DenseLayer {
         Sequential {
-            Dense<Parameter, Device>(inputSize: 512 * 6 * 6, outputSize: 4096)
+            Dense<Parameter, Device>(inputSize: 512 * 6 * 6, outputSize: 4096, using: &generator)
             BatchNorm<Parameter, Device>(inputSize: [4096])
             Relu<Parameter, Device>()
             Dropout<Parameter, Device>(rate: 0.5)
             
-            Dense<Parameter, Device>(inputSize: 4096, outputSize: 4096)
+            Dense<Parameter, Device>(inputSize: 4096, outputSize: 4096, using: &generator)
             BatchNorm<Parameter, Device>(inputSize: [4096])
             Relu<Parameter, Device>()
             Dropout<Parameter, Device>(rate: 0.5)
             
-            Dense<Parameter, Device>(inputSize: 4096, outputSize: classes)
+            Dense<Parameter, Device>(inputSize: 4096, outputSize: classes, using: &generator)
             LogSoftmax<Parameter, Device>()
         }
     }

--- a/Sources/DL4S/NN/Models/VGG/VGG11.swift
+++ b/Sources/DL4S/NN/Models/VGG/VGG11.swift
@@ -37,26 +37,36 @@ public struct VGG11<E: RandomizableType, D: DeviceType>: VGGBase {
     public var dense: DenseLayer
 
     public init(inputChannels: Int, classes: Int) {
+        var generator = WyHash()
+        self.init(inputChannels: inputChannels, classes: classes, using: &generator)
+    }
+
+    /// Creates a VGG11 image classification network.
+    /// - Parameters:
+    ///   - inputChannels: Number of input channels. Inputs must have the shape [batchSize, inputChannels, height, width].
+    ///   - classes: Number of classes / dimensionality of network output
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputChannels: Int, classes: Int, using generator: inout Generator) {
         conv1 = Sequential {
-            Convolution2D<E, D>(inputChannels: inputChannels, outputChannels: 64, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: inputChannels, outputChannels: 64, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [64, 1, 1])
             Relu<E, D>()
             MaxPool2D<E, D>()
         }
         
         conv2 = Sequential {
-            Convolution2D<E, D>(inputChannels: 64, outputChannels: 128, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 64, outputChannels: 128, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [128, 1, 1])
             Relu<E, D>()
             MaxPool2D<E, D>()
         }
         
         conv3 = Sequential {
-            Convolution2D<E, D>(inputChannels: 128, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 128, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
@@ -64,11 +74,11 @@ public struct VGG11<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv4 = Sequential {
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
@@ -76,17 +86,17 @@ public struct VGG11<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv5 = Sequential {
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
             MaxPool2D<E, D>()
         }
         
-        dense = Self.makeDense(classes: classes)
+        dense = Self.makeDense(classes: classes, using: &generator)
     }
 }

--- a/Sources/DL4S/NN/Models/VGG/VGG13.swift
+++ b/Sources/DL4S/NN/Models/VGG/VGG13.swift
@@ -37,12 +37,22 @@ public struct VGG13<E: RandomizableType, D: DeviceType>: VGGBase {
     public var dense: DenseLayer
     
     public init(inputChannels: Int, classes: Int) {
+        var generator = WyHash()
+        self.init(inputChannels: inputChannels, classes: classes, using: &generator)
+    }
+
+    /// Creates a VGG13 image classification network.
+    /// - Parameters:
+    ///   - inputChannels: Number of input channels. Inputs must have the shape [batchSize, inputChannels, height, width].
+    ///   - classes: Number of classes / dimensionality of network output
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputChannels: Int, classes: Int, using generator: inout Generator) {
         conv1 = Sequential {
-            Convolution2D<E, D>(inputChannels: inputChannels, outputChannels: 64, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: inputChannels, outputChannels: 64, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [64, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 64, outputChannels: 64, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 64, outputChannels: 64, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [64, 1, 1])
             Relu<E, D>()
             
@@ -50,11 +60,11 @@ public struct VGG13<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv2 = Sequential {
-            Convolution2D<E, D>(inputChannels: 64, outputChannels: 128, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 64, outputChannels: 128, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [128, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 128, outputChannels: 128, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 128, outputChannels: 128, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [128, 1, 1])
             Relu<E, D>()
             
@@ -62,11 +72,11 @@ public struct VGG13<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv3 = Sequential {
-            Convolution2D<E, D>(inputChannels: 128, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 128, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
@@ -74,11 +84,11 @@ public struct VGG13<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv4 = Sequential {
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
@@ -86,17 +96,17 @@ public struct VGG13<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv5 = Sequential {
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
             MaxPool2D<E, D>()
         }
         
-        dense = Self.makeDense(classes: classes)
+        dense = Self.makeDense(classes: classes, using: &generator)
     }
 }

--- a/Sources/DL4S/NN/Models/VGG/VGG16.swift
+++ b/Sources/DL4S/NN/Models/VGG/VGG16.swift
@@ -37,12 +37,22 @@ public struct VGG16<E: RandomizableType, D: DeviceType>: VGGBase {
     public var dense: DenseLayer
 
     public init(inputChannels: Int, classes: Int) {
+        var generator = WyHash()
+        self.init(inputChannels: inputChannels, classes: classes, using: &generator)
+    }
+
+    /// Creates a VGG16 image classification network.
+    /// - Parameters:
+    ///   - inputChannels: Number of input channels. Inputs must have the shape [batchSize, inputChannels, height, width].
+    ///   - classes: Number of classes / dimensionality of network output
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputChannels: Int, classes: Int, using generator: inout Generator) {
         conv1 = Sequential {
-            Convolution2D<E, D>(inputChannels: inputChannels, outputChannels: 64, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: inputChannels, outputChannels: 64, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [64, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 64, outputChannels: 64, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 64, outputChannels: 64, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [64, 1, 1])
             Relu<E, D>()
             
@@ -50,11 +60,11 @@ public struct VGG16<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv2 = Sequential {
-            Convolution2D<E, D>(inputChannels: 64, outputChannels: 128, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 64, outputChannels: 128, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [128, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 128, outputChannels: 128, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 128, outputChannels: 128, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [128, 1, 1])
             Relu<E, D>()
             
@@ -62,15 +72,15 @@ public struct VGG16<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv3 = Sequential {
-            Convolution2D<E, D>(inputChannels: 128, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 128, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
@@ -78,15 +88,15 @@ public struct VGG16<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv4 = Sequential {
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
@@ -94,21 +104,21 @@ public struct VGG16<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv5 = Sequential {
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
             MaxPool2D<E, D>()
         }
         
-        dense = Self.makeDense(classes: classes)
+        dense = Self.makeDense(classes: classes, using: &generator)
     }
 }

--- a/Sources/DL4S/NN/Models/VGG/VGG19.swift
+++ b/Sources/DL4S/NN/Models/VGG/VGG19.swift
@@ -37,12 +37,22 @@ public struct VGG19<E: RandomizableType, D: DeviceType>: VGGBase {
     public var dense: DenseLayer
 
     public init(inputChannels: Int, classes: Int) {
+        var generator = WyHash()
+        self.init(inputChannels: inputChannels, classes: classes, using: &generator)
+    }
+
+    /// Creates a VGG19 image classification network.
+    /// - Parameters:
+    ///   - inputChannels: Number of input channels. Inputs must have the shape [batchSize, inputChannels, height, width].
+    ///   - classes: Number of classes / dimensionality of network output
+    ///   - generator: Random number generator that provides the initial weights.
+    public init<Generator: RandomNumberGenerator>(inputChannels: Int, classes: Int, using generator: inout Generator) {
         conv1 = Sequential {
-            Convolution2D<E, D>(inputChannels: inputChannels, outputChannels: 64, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: inputChannels, outputChannels: 64, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [64, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 64, outputChannels: 64, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 64, outputChannels: 64, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [64, 1, 1])
             Relu<E, D>()
             
@@ -50,11 +60,11 @@ public struct VGG19<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv2 = Sequential {
-            Convolution2D<E, D>(inputChannels: 64, outputChannels: 128, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 64, outputChannels: 128, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [128, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 128, outputChannels: 128, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 128, outputChannels: 128, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [128, 1, 1])
             Relu<E, D>()
             
@@ -62,19 +72,19 @@ public struct VGG19<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv3 = Sequential {
-            Convolution2D<E, D>(inputChannels: 128, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 128, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 256, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [256, 1, 1])
             Relu<E, D>()
             
@@ -82,19 +92,19 @@ public struct VGG19<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv4 = Sequential {
-            Convolution2D<E, D>(inputChannels: 256, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 256, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
@@ -102,25 +112,25 @@ public struct VGG19<E: RandomizableType, D: DeviceType>: VGGBase {
         }
         
         conv5 = Sequential {
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
-            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3))
+            Convolution2D<E, D>(inputChannels: 512, outputChannels: 512, kernelSize: (3, 3), using: &generator)
             BatchNorm<E, D>(inputSize: [512, 1, 1])
             Relu<E, D>()
             
             MaxPool2D<E, D>()
         }
         
-        dense = Self.makeDense(classes: classes)
+        dense = Self.makeDense(classes: classes, using: &generator)
     }
 }

--- a/Sources/DL4S/Random.swift
+++ b/Sources/DL4S/Random.swift
@@ -34,34 +34,41 @@ extension Int32: RandomizableType {}
 extension Float: RandomizableType {}
 extension Double: RandomizableType {}
 
-struct WyHash: RandomNumberGenerator {
-    fileprivate static var shared = WyHash(seed: 0)
-    
+/// A small, fast pseudo random number generator.
+///
+/// Use `init(seed:)` together with the `using:` overloads of random tensor and layer initializers for reproducible initialization.
+///
+/// ```
+/// var generator = WyHash(seed: 42)
+/// let weights = Tensor<Float, CPU>(xavierNormalWithShape: [16, 8], using: &generator)
+/// let layer = Dense<Float, CPU>(inputSize: 16, outputSize: 8, using: &generator)
+/// ```
+public struct WyHash: RandomNumberGenerator, Sendable {
     private var state: UInt64
-
-    init(seed: UInt64) {
+    
+    /// Creates a generator that determistically generates randomness based on the provided seed.
+    /// - Parameter seed: Initial state of the generator.
+    public init(seed: UInt64) {
         state = seed
     }
-
-    mutating func next() -> UInt64 {
+    
+    /// Creates a generator with a seed from the system random number generator.
+    public init() {
+        var systemGenerator = SystemRandomNumberGenerator()
+        self.init(seed: systemGenerator.next())
+    }
+    
+    public mutating func next() -> UInt64 {
         state &+= 0xa0761d6478bd642f
         let (high, low) = state.multipliedFullWidth(by: state ^ 0xe7037ed1a0b428db)
         return high ^ low
     }
-    
-    mutating func next<T>() -> T where T : FixedWidthInteger, T : UnsignedInteger {
-        let n: UInt64 = next()
-        return T(clamping: n)
-    }
-    
-    mutating func next<T>(upperBound: T) -> T where T : FixedWidthInteger, T : UnsignedInteger {
-        return next() % upperBound
-    }
 }
 
-func randNormal<T: RandomizableType>(stdev: T, mean: T) -> (T, T) {
-    let a = T.random(in: 0 ... 1, using: &WyHash.shared)
-    let b = T.random(in: 0 ... 1, using: &WyHash.shared)
+/// Draws two independent values from a normal distribution with the Box-Muller transform.
+func randNormal<T: RandomizableType, Generator: RandomNumberGenerator>(stdev: T, mean: T, using generator: inout Generator) -> (T, T) {
+    let a = T.random(in: 0 ... 1, using: &generator)
+    let b = T.random(in: 0 ... 1, using: &generator)
     
     let scale = (-2 * a.log()).sqrt() * stdev
     
@@ -72,37 +79,77 @@ func randNormal<T: RandomizableType>(stdev: T, mean: T) -> (T, T) {
     if x.isFinite && !x.isNaN && y.isFinite && !y.isNaN {
         return (x, y)
     } else {
-        return randNormal(stdev: stdev, mean: mean)
+        return randNormal(stdev: stdev, mean: mean, using: &generator)
     }
 }
 
 public enum Random {
+    /// Fills the buffer with values from a uniform distribution in `a ... b`.
+    ///
+    /// - Parameters:
+    ///   - vector: Buffer to fill
+    ///   - a: Lower bound of the distribution
+    ///   - b: Upper bound of the distribution
     @_specialize(where Element == Float, Device == CPU)
     @_specialize(where Element == Double, Device == CPU)
     @_specialize(where Element == Int32, Device == CPU)
     public static func fill<Element: RandomizableType, Device>(_ vector: ShapedBuffer<Element, Device>, a: Element, b: Element) {
+        var generator = WyHash()
+        fill(vector, a: a, b: b, using: &generator)
+    }
+    
+    /// Fills the buffer with values from a uniform distribution in `a ... b`.
+    /// - Parameters:
+    ///   - vector: Buffer to fill
+    ///   - a: Lower bound of the distribution
+    ///   - b: Upper bound of the distribution
+    ///   - generator: Random number generator that provides the values
+    @_specialize(where Element == Float, Device == CPU, Generator == WyHash)
+    @_specialize(where Element == Double, Device == CPU, Generator == WyHash)
+    @_specialize(where Element == Int32, Device == CPU, Generator == WyHash)
+    public static func fill<Element: RandomizableType, Device, Generator: RandomNumberGenerator>(_ vector: ShapedBuffer<Element, Device>, a: Element, b: Element, using generator: inout Generator) {
         let buffer = UnsafeMutableBufferPointer<Element>.allocate(capacity: vector.count)
         let range = a ... b
         for i in 0 ..< vector.count {
-            buffer[i] = Element.random(in: range, using: &WyHash.shared)
+            buffer[i] = Element.random(in: range, using: &generator)
         }
         Device.Memory.assign(from: buffer.immutable, to: vector.values, count: vector.count)
         buffer.deallocate()
     }
     
+    /// Fills the buffer with values from a normal distribution.
+    /// - Parameters:
+    ///   - vector: Buffer to fill
+    ///   - mean: Mean of the distribution
+    ///   - stdev: Standard deviation of the distribution
     @_specialize(where Element == Float, Device == CPU)
     @_specialize(where Element == Double, Device == CPU)
     @_specialize(where Element == Int32, Device == CPU)
     public static func fillNormal<Element: RandomizableType, Device>(_ vector: ShapedBuffer<Element, Device>, mean: Element = 0, stdev: Element = 1) {
+        var generator = WyHash()
+        fillNormal(vector, mean: mean, stdev: stdev, using: &generator)
+    }
+    
+    /// Fills the buffer with values from a normal distribution.
+    /// - Parameters:
+    ///   - vector: Buffer to fill
+    ///   - mean: Mean of the distribution
+    ///   - stdev: Standard deviation of the distribution
+    ///   - generator: Random number generator that provides the values
+    @_specialize(where Element == Float, Device == CPU, Generator == WyHash)
+    @_specialize(where Element == Double, Device == CPU, Generator == WyHash)
+    @_specialize(where Element == Int32, Device == CPU, Generator == WyHash)
+    public static func fillNormal<Element: RandomizableType, Device, Generator: RandomNumberGenerator>(_ vector: ShapedBuffer<Element, Device>, mean: Element = 0, stdev: Element = 1, using generator: inout Generator) {
         let buffer = UnsafeMutableBufferPointer<Element>.allocate(capacity: vector.count)
         for i in stride(from: 0, to: vector.count - 1, by: 2) {
-            let (a, b) = randNormal(stdev: stdev, mean: mean)
+            let (a, b) = randNormal(stdev: stdev, mean: mean, using: &generator)
             buffer[i] = a
             buffer[i+1] = b
         }
         
-        if vector.count % 2 == 0 {
-            let (a, _) = randNormal(stdev: stdev, mean: mean)
+        // The Box-Muller transform yields pairs. An odd count needs one more value for the last element.
+        if vector.count % 2 == 1 {
+            let (a, _) = randNormal(stdev: stdev, mean: mean, using: &generator)
             buffer[vector.count-1] = a
         }
         Device.Memory.assign(from: buffer.immutable, to: vector.values, count: vector.count)
@@ -142,14 +189,33 @@ public enum Random {
         return (randomSamples, randomLabels)
     }
     
+    /// Fills the buffer with ones and zeros. Each element is 1 with probability `p`.
+    ///
+    /// The values come from a new generator with a random seed. Use `bernoulli(_:p:using:)` for reproducible values.
+    /// - Parameters:
+    ///   - values: Buffer to fill
+    ///   - p: Probability of a 1
     @_specialize(where Element == Float, Device == CPU)
     @_specialize(where Element == Int32, Device == CPU)
     @_specialize(where Element == Double, Device == CPU)
     public static func bernoulli<Element: NumericType, Device>(_ values: ShapedBuffer<Element, Device>, p: Float) {
+        var generator = WyHash()
+        bernoulli(values, p: p, using: &generator)
+    }
+    
+    /// Fills the buffer with ones and zeros. Each element is 1 with probability `p`.
+    /// - Parameters:
+    ///   - values: Buffer to fill
+    ///   - p: Probability of a 1
+    ///   - generator: Random number generator to draw from
+    @_specialize(where Element == Float, Device == CPU, Generator == WyHash)
+    @_specialize(where Element == Int32, Device == CPU, Generator == WyHash)
+    @_specialize(where Element == Double, Device == CPU, Generator == WyHash)
+    public static func bernoulli<Element: NumericType, Device, Generator: RandomNumberGenerator>(_ values: ShapedBuffer<Element, Device>, p: Float, using generator: inout Generator) {
         let count = values.shape.reduce(1, *)
         let buffer = UnsafeMutableBufferPointer<Element>.allocate(capacity: count)
         for i in 0 ..< count {
-            buffer[i] = Float.random(in: 0 ... 1, using: &WyHash.shared) <= p ? 1 : 0
+            buffer[i] = Float.random(in: 0 ... 1, using: &generator) <= p ? 1 : 0
         }
         
         Device.Memory.assign(from: buffer.immutable, to: values.values, count: count)

--- a/Sources/DL4S/Random.swift
+++ b/Sources/DL4S/Random.swift
@@ -93,7 +93,7 @@ public enum Random {
     @_specialize(where Element == Float, Device == CPU)
     @_specialize(where Element == Double, Device == CPU)
     @_specialize(where Element == Int32, Device == CPU)
-    public static func fill<Element: RandomizableType, Device>(_ vector: ShapedBuffer<Element, Device>, a: Element, b: Element) {
+    public static func fill<Element: RandomizableType, Device>(_ vector: MutableShapedBuffer<Element, Device>, a: Element, b: Element) {
         var generator = WyHash()
         fill(vector, a: a, b: b, using: &generator)
     }
@@ -107,7 +107,7 @@ public enum Random {
     @_specialize(where Element == Float, Device == CPU, Generator == WyHash)
     @_specialize(where Element == Double, Device == CPU, Generator == WyHash)
     @_specialize(where Element == Int32, Device == CPU, Generator == WyHash)
-    public static func fill<Element: RandomizableType, Device, Generator: RandomNumberGenerator>(_ vector: ShapedBuffer<Element, Device>, a: Element, b: Element, using generator: inout Generator) {
+    public static func fill<Element: RandomizableType, Device, Generator: RandomNumberGenerator>(_ vector: MutableShapedBuffer<Element, Device>, a: Element, b: Element, using generator: inout Generator) {
         let buffer = UnsafeMutableBufferPointer<Element>.allocate(capacity: vector.count)
         let range = a ... b
         for i in 0 ..< vector.count {
@@ -125,7 +125,7 @@ public enum Random {
     @_specialize(where Element == Float, Device == CPU)
     @_specialize(where Element == Double, Device == CPU)
     @_specialize(where Element == Int32, Device == CPU)
-    public static func fillNormal<Element: RandomizableType, Device>(_ vector: ShapedBuffer<Element, Device>, mean: Element = 0, stdev: Element = 1) {
+    public static func fillNormal<Element: RandomizableType, Device>(_ vector: MutableShapedBuffer<Element, Device>, mean: Element = 0, stdev: Element = 1) {
         var generator = WyHash()
         fillNormal(vector, mean: mean, stdev: stdev, using: &generator)
     }
@@ -139,7 +139,7 @@ public enum Random {
     @_specialize(where Element == Float, Device == CPU, Generator == WyHash)
     @_specialize(where Element == Double, Device == CPU, Generator == WyHash)
     @_specialize(where Element == Int32, Device == CPU, Generator == WyHash)
-    public static func fillNormal<Element: RandomizableType, Device, Generator: RandomNumberGenerator>(_ vector: ShapedBuffer<Element, Device>, mean: Element = 0, stdev: Element = 1, using generator: inout Generator) {
+    public static func fillNormal<Element: RandomizableType, Device, Generator: RandomNumberGenerator>(_ vector: MutableShapedBuffer<Element, Device>, mean: Element = 0, stdev: Element = 1, using generator: inout Generator) {
         let buffer = UnsafeMutableBufferPointer<Element>.allocate(capacity: vector.count)
         for i in stride(from: 0, to: vector.count - 1, by: 2) {
             let (a, b) = randNormal(stdev: stdev, mean: mean, using: &generator)
@@ -198,7 +198,7 @@ public enum Random {
     @_specialize(where Element == Float, Device == CPU)
     @_specialize(where Element == Int32, Device == CPU)
     @_specialize(where Element == Double, Device == CPU)
-    public static func bernoulli<Element: NumericType, Device>(_ values: ShapedBuffer<Element, Device>, p: Float) {
+    public static func bernoulli<Element: NumericType, Device>(_ values: MutableShapedBuffer<Element, Device>, p: Float) {
         var generator = WyHash()
         bernoulli(values, p: p, using: &generator)
     }
@@ -211,7 +211,7 @@ public enum Random {
     @_specialize(where Element == Float, Device == CPU, Generator == WyHash)
     @_specialize(where Element == Int32, Device == CPU, Generator == WyHash)
     @_specialize(where Element == Double, Device == CPU, Generator == WyHash)
-    public static func bernoulli<Element: NumericType, Device, Generator: RandomNumberGenerator>(_ values: ShapedBuffer<Element, Device>, p: Float, using generator: inout Generator) {
+    public static func bernoulli<Element: NumericType, Device, Generator: RandomNumberGenerator>(_ values: MutableShapedBuffer<Element, Device>, p: Float, using generator: inout Generator) {
         let count = values.shape.reduce(1, *)
         let buffer = UnsafeMutableBufferPointer<Element>.allocate(capacity: count)
         for i in 0 ..< count {

--- a/Sources/DL4S/Tensor/Context.swift
+++ b/Sources/DL4S/Tensor/Context.swift
@@ -22,15 +22,33 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
+//
 
 import Foundation
 
 @usableFromInline
 struct TensorContext<Element: NumericType, Device: DeviceType> {
+    /// Describes how the gradient of the result flows back to the sources of an operation.
+    @usableFromInline
+    enum BackpropagateFunction {
+        /// One closure per source.
+        ///
+        /// Each closure receives the gradient of the result and the accumulated gradient of its source.
+        /// It adds the gradient of the result with respect to its source to the accumulator and returns the sum.
+        case perSource([(Tensor<Element, Device>, consuming Tensor<Element, Device>?) -> Tensor<Element, Device>])
+        
+        /// One closure for all sources.
+        ///
+        /// The closure receives the gradient of the result and one accumulator per source.
+        /// It returns the accumulated gradient of every source in source order.
+        /// Operations use this form when one kernel produces the gradients of all sources at once,
+        /// so the kernel runs once per backward pass and no state needs to be shared between closures.
+        case allSources((Tensor<Element, Device>, consuming [Tensor<Element, Device>?]) -> [Tensor<Element, Device>])
+    }
+    
     var tag: String?
     var sources: [Tensor<Element, Device>]
-    /// Each closure adds the gradient of the result with respect to its source to the accumulator and returns the sum.
-    var backpropagate: [(Tensor<Element, Device>, consuming Tensor<Element, Device>?) -> Tensor<Element, Device>]
+    var backpropagate: BackpropagateFunction
     #if DEBUG
     var operationStack = OperationGroup.operationStack
     #endif
@@ -47,6 +65,18 @@ struct TensorContext<Element: NumericType, Device: DeviceType> {
     init(tag: String?, sources: [Tensor<Element, Device>], backpropagateAccumulate: [(Tensor<Element, Device>, consuming Tensor<Element, Device>?) -> Tensor<Element, Device>]) {
         self.tag = tag
         self.sources = sources
-        self.backpropagate = backpropagateAccumulate
+        self.backpropagate = .perSource(backpropagateAccumulate)
+    }
+    
+    /// Creates a context with one backpropagation closure for all sources.
+    ///
+    /// - Parameters:
+    ///   - tag: Name of the operation for graph output.
+    ///   - sources: Tensors that the operation reads.
+    ///   - backpropagateAll: Closure that receives the gradient of the result and owns one accumulator per source, and returns the accumulated gradient of every source.
+    init(tag: String?, sources: [Tensor<Element, Device>], backpropagateAll: @escaping (Tensor<Element, Device>, consuming [Tensor<Element, Device>?]) -> [Tensor<Element, Device>]) {
+        self.tag = tag
+        self.sources = sources
+        self.backpropagate = .allSources(backpropagateAll)
     }
 }

--- a/Sources/DL4S/Tensor/Context.swift
+++ b/Sources/DL4S/Tensor/Context.swift
@@ -29,7 +29,8 @@ import Foundation
 struct TensorContext<Element: NumericType, Device: DeviceType> {
     var tag: String?
     var sources: [Tensor<Element, Device>]
-    var backpropagate: [(Tensor<Element, Device>, Tensor<Element, Device>?) -> Tensor<Element, Device>]
+    /// Each closure adds the gradient of the result with respect to its source to the accumulator and returns the sum.
+    var backpropagate: [(Tensor<Element, Device>, consuming Tensor<Element, Device>?) -> Tensor<Element, Device>]
     #if DEBUG
     var operationStack = OperationGroup.operationStack
     #endif
@@ -37,16 +38,13 @@ struct TensorContext<Element: NumericType, Device: DeviceType> {
     init(tag: String?, sources: [Tensor<Element, Device>], backpropagate: [(Tensor<Element, Device>) -> Tensor<Element, Device>]) {
         self.init(tag: tag, sources: sources, backpropagateAccumulate: backpropagate.map { function in
             { resultGradient, accumulator in
-                if let acc = accumulator {
-                    return acc + function(resultGradient)
-                } else {
-                    return function(resultGradient)
-                }
+                let gradient = function(resultGradient)
+                return accumulator.map { $0 + gradient } ?? gradient
             }
         })
     }
     
-    init(tag: String?, sources: [Tensor<Element, Device>], backpropagateAccumulate: [(Tensor<Element, Device>, Tensor<Element, Device>?) -> Tensor<Element, Device>]) {
+    init(tag: String?, sources: [Tensor<Element, Device>], backpropagateAccumulate: [(Tensor<Element, Device>, consuming Tensor<Element, Device>?) -> Tensor<Element, Device>]) {
         self.tag = tag
         self.sources = sources
         self.backpropagate = backpropagateAccumulate

--- a/Sources/DL4S/Tensor/Graph.swift
+++ b/Sources/DL4S/Tensor/Graph.swift
@@ -127,26 +127,28 @@ extension Digraph: CustomStringConvertible {
 }
 
 
+#if DEBUG
+/// One level of the operation stack that `OperationGroup.capture(named:_:)` records.
+struct OperationGroupEntry: Sendable, Hashable {
+    /// Distinguishes captures with the same name.
+    let id: UInt64
+    
+    /// Name that `Tensor.graph()` shows for the group.
+    let name: String
+}
+#endif
+
 /// OperationGroup allows the grouping of operations in the compute graph.
 /// This improves the readability, when displaying the compute graph using `result.graph()`.
 /// It has no effect on the way that computations are performed. When optimization is enabled,
 /// operation groups are not captured.
 public enum OperationGroup {
-    @ThreadLocal static private(set) var operationStack: [(id: UInt64, name: String)] = []
-    
-    @inline(__always)
-    static func push(_ name: @autoclosure () -> String) {
-        #if DEBUG
-        operationStack.append((id: UInt64.random(in: 0 ... UInt64.max), name: name()))
-        #endif
-    }
-    
-    @inline(__always)
-    static func pop() {
-        #if DEBUG
-        operationStack.removeLast()
-        #endif
-    }
+    #if DEBUG
+    /// Groups that enclose the current operation, outermost first.
+    ///
+    /// Task-local, so parallel tasks and threads have their own stack.
+    @TaskLocal static var operationStack: [OperationGroupEntry] = []
+    #endif
     
     /// Captures a group of operations that is displayed within a box in the compute graph, when using `result.graph()`.
     /// Only applicable for debug builds. In release builds, the operation closure is executed but otherwise, the operation group has no effect.
@@ -155,10 +157,14 @@ public enum OperationGroup {
     ///   - operations: Operations to group
     @inline(__always)
     public static func capture<Output>(named name: String, _ operations: () -> Output) -> Output {
-        push(name)
-        let result = operations()
-        pop()
-        return result
+        #if DEBUG
+        let entry = OperationGroupEntry(id: UniqueID.next(), name: name)
+        return $operationStack.withValue(operationStack + [entry]) {
+            operations()
+        }
+        #else
+        return operations()
+        #endif
     }
 }
 

--- a/Sources/DL4S/Tensor/Operators/Binary.swift
+++ b/Sources/DL4S/Tensor/Operators/Binary.swift
@@ -185,11 +185,8 @@ public extension Tensor {
                                 tmpReducedShape.remove(at: a)
                             }
                             
-                            if let acc = acc {
-                                return acc + resultGradient.reduceSum(along: lhsReducedAxes).view(as: lhs.shape)
-                            } else {
-                                return resultGradient.reduceSum(along: lhsReducedAxes).view(as: lhs.shape)
-                            }
+                            let gradient = resultGradient.reduceSum(along: lhsReducedAxes).view(as: lhs.shape)
+                            return acc.map { $0 + gradient } ?? gradient
                             
                         }
                     }, { resultGradient, acc in
@@ -204,11 +201,8 @@ public extension Tensor {
                                 tmpReducedShape.remove(at: a)
                             }
                             
-                            if let acc = acc {
-                                return acc - resultGradient.reduceSum(along: rhsReducedAxes).view(as: rhs.shape)
-                            } else {
-                                return -resultGradient.reduceSum(along: rhsReducedAxes).view(as: rhs.shape)
-                            }
+                            let gradient = resultGradient.reduceSum(along: rhsReducedAxes).view(as: rhs.shape)
+                            return acc.map { $0 - gradient } ?? -gradient
                         }
                     }
                 ]
@@ -247,7 +241,7 @@ public extension Tensor {
                 tag: "÷",
                 sources: [lhs, rhs],
                 backpropagateAccumulate: [
-                    { resultGradient, acc -> Self in
+                    { resultGradient, acc in
                         OperationGroup.capture(named: "∇₁÷") {
                             let lhsPadded = Array(repeating: 1, count: resultGradient.dim - lhs.dim) + lhs.shape
                             let lhsReducedAxes = zip(lhsPadded, resultGradient.shape).enumerated()
@@ -260,14 +254,11 @@ public extension Tensor {
                             }
                             
                             let d = resultGradient / rhs
-                            if let acc = acc {
-                                return acc + d.reduceSum(along: lhsReducedAxes).view(as: lhs.shape)
-                            } else {
-                                return d.reduceSum(along: lhsReducedAxes).view(as: lhs.shape)
-                            }
+                            let gradient = d.reduceSum(along: lhsReducedAxes).view(as: lhs.shape)
+                            return acc.map { $0 + gradient } ?? gradient
                             
                         }
-                    }, { resultGradient, acc -> Self in
+                    }, { resultGradient, acc in
                         OperationGroup.capture(named: "∇₂÷") {
                             let rhsPadded = Array(repeating: 1, count: resultGradient.dim - rhs.dim) + rhs.shape
                             let rhsReducedAxes = zip(rhsPadded, resultGradient.shape).enumerated()
@@ -281,11 +272,8 @@ public extension Tensor {
                             
                             let m = resultGradient * lhs
                             let d = m / (rhs * rhs)
-                            if let acc = acc {
-                                return acc - d.reduceSum(along: rhsReducedAxes).view(as: rhs.shape)
-                            } else {
-                                return -d.reduceSum(along: rhsReducedAxes).view(as: rhs.shape)
-                            }
+                            let gradient = d.reduceSum(along: rhsReducedAxes).view(as: rhs.shape)
+                            return acc.map { $0 - gradient } ?? -gradient
                         }
                     }
                 ]

--- a/Sources/DL4S/Tensor/Operators/Matrix.swift
+++ b/Sources/DL4S/Tensor/Operators/Matrix.swift
@@ -139,111 +139,71 @@ public extension Tensor {
             context: (self.requiresGradient || other.requiresGradient) ? TensorContext(
                 tag: "mmul",
                 sources: [self, other],
-                backpropagateAccumulate: [
-                    { resultGradient, acc in
-                        let res: Self
-                        if let acc = acc {
-                            let acc = transposeSelf ? acc.transposed() : acc
-                            res = resultGradient._matMulAdd(other, add: acc, transposeSelf: false, transposeOther: !transposeOther, inplaceAdd: !acc.requiresGradient)
-                        } else {
-                             res = resultGradient._matMul(other, transposeSelf: false, transposeOther: !transposeOther)
-                        }
-                        
-                        if transposeSelf {
-                            return res.transposed()
-                        } else {
-                            return res
-                        }
-                    }, { resultGradient, acc in
-                        let res: Self
-                        
-                        if let acc = acc {
-                            let acc = transposeOther ? acc.transposed() : acc
-                            res = self._matMulAdd(resultGradient, add: acc, transposeSelf: !transposeSelf, transposeOther: false, inplaceAdd: !acc.requiresGradient)
-                        } else {
-                            res = self._matMul(resultGradient, transposeSelf: !transposeSelf, transposeOther: false)
-                        }
-                        
-                        if transposeOther {
-                            return res.transposed()
-                        } else {
-                            return res
-                        }
-                    }
-                ]
+                backpropagateAccumulate: Self.matMulBackwards(lhs: self, rhs: other, transposeLhs: transposeSelf, transposeRhs: transposeOther)
             ) : nil
         )
     }
     
-    private func _matMulAdd(_ other: Self, add: Self, transposeSelf: Bool = false, transposeOther: Bool = false, inplaceAdd: Bool = false) -> Self {
-        precondition(self.dim == 2)
-        precondition(other.dim == 2)
-        precondition(self.shape[transposeSelf ? 0 : 1] == other.shape[transposeOther ? 1 : 0])
-        
-        let resultShape = [self.shape[transposeSelf ? 1 : 0], other.shape[transposeOther ? 0 : 1]]
-        precondition(resultShape == add.shape)
-        
-        var target = add
-        if !inplaceAdd {
-            target.ensureOwnership()
-        }
-        
-        Device.Engine.gemm(
-            lhs: self.values,
-            rhs: other.values,
-            result: target.values,
-            alpha: 1,
-            beta: 1,
-            transposeFirst: transposeSelf,
-            transposeSecond: transposeOther
-        )
-        
-        if self.requiresGradient || other.requiresGradient || add.requiresGradient {
-            target.requiresGradient = true
-            target.context = TensorContext(
-                tag: "gemm",
-                sources: [self, other, add],
-                backpropagateAccumulate: [
-                    { resultGradient, sourceGradient in
-                        if let src = sourceGradient {
-                            let res = resultGradient._matMulAdd(other, add: transposeSelf ? src.transposed() : src, transposeSelf: false, transposeOther: !transposeOther)
-                            if transposeSelf {
-                                return res.transposed()
-                            } else {
-                                return res
-                            }
-                        } else {
-                            let res = resultGradient._matMul(other, transposeSelf: false, transposeOther: !transposeOther)
-                            if transposeSelf {
-                                return res.transposed()
-                            } else {
-                                return res
-                            }
-                        }
-                    }, { resultGradient, sourceGradient in
-                        if let src = sourceGradient {
-                            let res = self._matMulAdd(resultGradient, add: transposeOther ? src.transposed() : src, transposeSelf: !transposeSelf, transposeOther: false)
-                            if transposeOther {
-                                return res.transposed()
-                            } else {
-                                return res
-                            }
-                        } else {
-                            let res = self._matMul(resultGradient, transposeSelf: !transposeSelf, transposeOther: false)
-                            if transposeOther {
-                                return res.transposed()
-                            } else {
-                                return res
-                            }
-                        }
-                    }, { resultGradient, sourceGradient in
-                        sourceGradient.map {$0 + resultGradient} ?? resultGradient
-                    }
-                ]
+    /// Returns the matrix product of `self` and `other` added to `add`. When `add` is nil, returns the product.
+    private func _matMulAdd(_ other: Self, add: consuming Self?, transposeSelf: Bool = false, transposeOther: Bool = false) -> Self {
+        switch consume add {
+        case .none:
+            return _matMul(other, transposeSelf: transposeSelf, transposeOther: transposeOther)
+        case .some(var target):
+            precondition(self.dim == 2)
+            precondition(other.dim == 2)
+            precondition(self.shape[transposeSelf ? 0 : 1] == other.shape[transposeOther ? 1 : 0])
+            precondition(target.shape == [self.shape[transposeSelf ? 1 : 0], other.shape[transposeOther ? 0 : 1]])
+            
+            // When we're capturing a graph, we need target pre-addition. Without a graph, we can work in-place.
+            let original = target.requiresGradient ? target : nil
+            
+            Device.Engine.gemm(
+                lhs: self.values,
+                rhs: other.values,
+                result: target.mutableValues,
+                alpha: 1,
+                beta: 1,
+                transposeFirst: transposeSelf,
+                transposeSecond: transposeOther
             )
+            
+            guard self.requiresGradient || other.requiresGradient || original != nil else {
+                return target
+            }
+            
+            var sources = [self, other]
+            var backpropagate = Self.matMulBackwards(lhs: self, rhs: other, transposeLhs: transposeSelf, transposeRhs: transposeOther)
+            if let original = original {
+                sources.append(original)
+                backpropagate.append { resultGradient, acc in
+                    acc.map { $0 + resultGradient } ?? resultGradient
+                }
+            }
+            target.context = TensorContext(tag: "gemm", sources: sources, backpropagateAccumulate: backpropagate)
+            target.requiresGradient = true
+            return target
         }
-        
-        return target
+    }
+    
+    /// Backpropagation closures for the product of `lhs` and `rhs`, one per operand.
+    private static func matMulBackwards(lhs: Self, rhs: Self, transposeLhs: Bool, transposeRhs: Bool) -> [(Self, consuming Self?) -> Self] {
+        [
+            { resultGradient, acc in
+                if transposeLhs {
+                    return rhs._matMulAdd(resultGradient, add: acc, transposeSelf: transposeRhs, transposeOther: true)
+                } else {
+                    return resultGradient._matMulAdd(rhs, add: acc, transposeSelf: false, transposeOther: !transposeRhs)
+                }
+            },
+            { resultGradient, acc in
+                if transposeRhs {
+                    return resultGradient._matMulAdd(lhs, add: acc, transposeSelf: true, transposeOther: transposeLhs)
+                } else {
+                    return lhs._matMulAdd(resultGradient, add: acc, transposeSelf: !transposeLhs, transposeOther: false)
+                }
+            }
+        ]
     }
 }
 

--- a/Sources/DL4S/Tensor/Operators/Shape.swift
+++ b/Sources/DL4S/Tensor/Operators/Shape.swift
@@ -168,19 +168,14 @@ public extension Tensor {
         if self.requiresGradient || other.requiresGradient {
             let original = self
             
-            ensureOwnership()
-            Device.Engine.permuteAxesAdd(values: other.values, add: self.values, result: self.values, arangement: permutation)
+            Device.Engine.permuteAxesAdd(values: other.values, add: original.values, result: self.mutableValues, arangement: permutation)
             let dim = self.dim
             self.context = TensorContext(
                 tag: "permutedAdd",
                 sources: [original, other],
                 backpropagateAccumulate: [
                     { resultGradient, acc in
-                        if let acc = acc {
-                            return acc + resultGradient
-                        } else {
-                            return resultGradient
-                        }
+                        acc.map { $0 + resultGradient } ?? resultGradient
                     }, { resultGradient, acc in
                         var invArangement = [Int](repeating: 0, count: dim)
                         for (i, j) in permutation.enumerated() {
@@ -196,8 +191,8 @@ public extension Tensor {
                 ]
             )
         } else {
-            ensureOwnership()
-            Device.Engine.permuteAxesAdd(values: other.values, add: self.values, result: self.values, arangement: permutation)
+            let target = self.mutableValues
+            Device.Engine.permuteAxesAdd(values: other.values, add: ShapedBuffer(target), result: target, arangement: permutation)
         }
     }
     

--- a/Sources/DL4S/Tensor/Operators/Stack.swift
+++ b/Sources/DL4S/Tensor/Operators/Stack.swift
@@ -97,26 +97,25 @@ public extension Tensor {
         let resultBuffer = Device.Memory.allocateBuffer(withShape: resultShape, type: Element.self)
         Device.Engine.stack(buffers: tensors.map {$0.values}, result: resultBuffer, axis: axis)
         
-        var gradientCache: [UInt64: [Self]] = [:]
-        
         self.init(
             using: resultBuffer,
             context: requiresGradient ? TensorContext(
                 tag: "stack",
                 sources: tensors,
-                backpropagate: tensors.indices.map { i in { resultGradient in
-                    if resultGradient.requiresGradient {
-                        // caching gradients leads to retain cycles when the backwards pass is retained.
-                        // therefore, caching is disabled in this case as a workaround.
-                        return resultGradient.unstacked(along: axis, withLengths: resultStackDimSize)[i]
-                    } else if let cache = gradientCache[resultGradient.backpropID] {
-                        return cache[i]
-                    } else {
-                        let v = resultGradient.unstacked(along: axis, withLengths: resultStackDimSize)
-                        gradientCache[resultGradient.backpropID] = v
-                        return v[i]
+                // One closure for all sources, so the gradient is unstacked once per backward visit
+                // and the closures share no state.
+                backpropagateAll: { resultGradient, accumulators in
+                    var accumulators = accumulators
+                    let sourceGradients = resultGradient.unstacked(along: axis, withLengths: resultStackDimSize)
+                    return sourceGradients.indices.map { i in
+                        // Taking the accumulator out of the array leaves it uniquely referenced.
+                        if let accumulator = accumulators[i].take() {
+                            return accumulator + sourceGradients[i]
+                        } else {
+                            return sourceGradients[i]
+                        }
                     }
-                }}
+                }
             ) : nil
         )
     }

--- a/Sources/DL4S/Tensor/Operators/Subscript.swift
+++ b/Sources/DL4S/Tensor/Operators/Subscript.swift
@@ -58,7 +58,7 @@ public extension Tensor {
                     tag: "read",
                     sources: [self],
                     backpropagateAccumulate: [{ resultGradient, acc in
-                        var result = (acc ?? Self(repeating: 0, shape: self.shape))
+                        var result = acc ?? Self(repeating: 0, shape: self.shape)
                         result[index] = resultGradient
                         return result
                     }]
@@ -68,8 +68,6 @@ public extension Tensor {
         
         set (slice) {
             precondition(!requiresGradient, "Cannot write into tensor that requires gradient.")
-            
-            self.ensureOwnership()
             
             let index = zip(index, shape).map { idx, dim -> Int? in
                 if let idx = idx, idx < 0 {
@@ -84,7 +82,7 @@ public extension Tensor {
             
             //TODO: Proper handling of replacement when gradient is computed.
             
-            Device.Memory.set(slice: index, of: values.values, with: shape, from: slice.values.values, with: slice.shape)
+            Device.Memory.set(slice: index, of: mutableValues.values, with: shape, from: slice.values.values, with: slice.shape)
             
             if slice.requiresGradient {
                 self.requiresGradient = true
@@ -143,7 +141,7 @@ public extension Tensor {
                     tag: "SubscriptRangeRead",
                     sources: [self],
                     backpropagateAccumulate: [{ resultGradient, acc in
-                        var result = (acc ?? Self(repeating: 0, shape: self.shape))
+                        var result = acc ?? Self(repeating: 0, shape: self.shape)
                         result[index] = resultGradient
                         return result
                     }]
@@ -156,11 +154,9 @@ public extension Tensor {
                 fatalError("Assigning from a single value not supported yet.")
             }
             
-            self.ensureOwnership()
-            
             //TODO: Proper handling of replacement when gradient is computed.
             
-            Device.Memory.set(slice: index, of: values.values, with: shape, from: slice.values.values, with: slice.shape)
+            Device.Memory.set(slice: index, of: mutableValues.values, with: shape, from: slice.values.values, with: slice.shape)
             
             if slice.requiresGradient {
                 self.requiresGradient = true

--- a/Sources/DL4S/Tensor/Operators/Subscript.swift
+++ b/Sources/DL4S/Tensor/Operators/Subscript.swift
@@ -59,7 +59,9 @@ public extension Tensor {
                     sources: [self],
                     backpropagateAccumulate: [{ resultGradient, acc in
                         var result = acc ?? Self(repeating: 0, shape: self.shape)
-                        result[index] = resultGradient
+                        // The slice view must be released before the write, or the write copies the whole accumulator.
+                        let slice = result[index] + resultGradient
+                        result[index] = slice
                         return result
                     }]
                 ) : nil
@@ -142,7 +144,9 @@ public extension Tensor {
                     sources: [self],
                     backpropagateAccumulate: [{ resultGradient, acc in
                         var result = acc ?? Self(repeating: 0, shape: self.shape)
-                        result[index] = resultGradient
+                        // The slice view must be released before the write, or the write copies the whole accumulator.
+                        let slice = result[index] + resultGradient
+                        result[index] = slice
                         return result
                     }]
                 ) : nil

--- a/Sources/DL4S/Tensor/Tensor.swift
+++ b/Sources/DL4S/Tensor/Tensor.swift
@@ -27,10 +27,10 @@ import Foundation
 
 
 final class TensorHandle<Element, Device: DeviceType> {
-    var values: Buffer<Element, Device>
+    var values: MutableBuffer<Element, Device>
     var parent: TensorHandle<Element, Device>?
     
-    init(values: Buffer<Element, Device>, parent: TensorHandle<Element, Device>? = nil) {
+    init(values: MutableBuffer<Element, Device>, parent: TensorHandle<Element, Device>? = nil) {
         self.values = values
         self.parent = parent
     }
@@ -85,8 +85,9 @@ public struct Tensor<Element: NumericType, Device: DeviceType> {
     public var tag: String? = nil
     #endif
     
+    /// Read-only view of the storage of the tensor.
     var values: ShapedBuffer<Element, Device> {
-        ShapedBuffer(values: handle.values, shape: shape)
+        ShapedBuffer(values: Buffer(handle.values), shape: shape)
     }
     
     /// Number of elements in the tensor.
@@ -161,7 +162,7 @@ public struct Tensor<Element: NumericType, Device: DeviceType> {
         self.init(v, shape: shape, requiresGradient: requiresGradient)
     }
     
-    init(using values: ShapedBuffer<Element, Device>, context: TensorContext<Element, Device>?) {
+    init(using values: MutableShapedBuffer<Element, Device>, context: TensorContext<Element, Device>?) {
         handle = TensorHandle(values: values.values)
         self.context = context
         self.requiresGradient = context != nil
@@ -256,24 +257,25 @@ public struct Tensor<Element: NumericType, Device: DeviceType> {
                 continue
             }
             // Add gradients of all tensors that directly influenced the values
-            // of the current tensor to their respective accumulators
+            // of the current tensor to their respective accumulators.
+            // The accumulator is removed from the dictionary and consumed by the closure,
+            // to prevent extraneous copies through the CoW mechanism.
             for i in ctx.sources.indices {
                 let src = ctx.sources[i]
-                let fn = ctx.backpropagate[i]
                 
                 guard src.requiresGradient else {
                     continue
                 }
                 
-                let srcGrad = fn(grad, grads[src.backpropID])
+                let accumulator = ctx.backpropagate[i](grad, grads.removeValue(forKey: src.backpropID))
                 #if DEBUG
-                assert(srcGrad.shape == src.shape)
+                assert(accumulator.shape == src.shape)
                 #endif
                 
                 if retainGraph {
-                    grads[src.backpropID] = srcGrad
+                    grads[src.backpropID] = accumulator
                 } else {
-                    grads[src.backpropID] = srcGrad.detached()
+                    grads[src.backpropID] = accumulator.detached()
                 }
             }
         }
@@ -286,6 +288,10 @@ public struct Tensor<Element: NumericType, Device: DeviceType> {
         return targetGrads
     }
     
+    /// Ensures storage is not shared with other tensors.
+    ///
+    /// Operations like `view` avoid extraneous copies of the underlying memory.
+    /// In place mutations must ensure that no other tensors reference the same storage.
     mutating func ensureOwnership() {
         if isKnownUniquelyReferenced(&handle) && handle.parent == nil {
             return
@@ -295,16 +301,16 @@ public struct Tensor<Element: NumericType, Device: DeviceType> {
         let replacementHandle = TensorHandle(values:
             Device.Memory.allocateBuffer(withShape: shape, type: Element.self).values
         )
-        Device.Memory.assign(from: handle.values, to: replacementHandle.values, count: count)
+        Device.Memory.assign(from: Buffer(handle.values), to: replacementHandle.values, count: count)
         
         self = Tensor(
             handle: replacementHandle,
             shape: shape,
-            context: TensorContext(
+            context: requiresGradient ? TensorContext(
                 tag: "identity",
                 sources: [original],
                 backpropagate: [{$0}]
-            )
+            ) : nil
         )
     }
     

--- a/Sources/DL4S/Tensor/Tensor.swift
+++ b/Sources/DL4S/Tensor/Tensor.swift
@@ -24,7 +24,20 @@
 //  SOFTWARE.
 
 import Foundation
+import Synchronization
 
+/// Mints identifiers that are unique within one process.
+///
+/// A counter is cheaper than the system random number generator, which takes a process-wide lock on every call.
+enum UniqueID {
+    private static let counter = Atomic<UInt64>(0)
+    
+    /// Returns an identifier that no earlier call has returned.
+    @inline(__always)
+    static func next() -> UInt64 {
+        counter.wrappingAdd(1, ordering: .relaxed).newValue
+    }
+}
 
 final class TensorHandle<Element, Device: DeviceType> {
     var values: MutableBuffer<Element, Device>
@@ -51,8 +64,9 @@ public struct Tensor<Element: NumericType, Device: DeviceType> {
     
     /// Identifies the tensor during backpropagation.
     ///
-    /// The id will vary across different runs and different tensors with the same values.
-    let backpropID: UInt64 = UInt64.random(in: 0 ... UInt64.max)
+    /// Copies of a tensor share the id. A tensor that `ensureOwnership` creates gets a new id.
+    /// Different tensors with the same values have different ids.
+    let backpropID: UInt64 = UniqueID.next()
     
     /// Shape of the tensor.
     ///
@@ -231,61 +245,91 @@ public struct Tensor<Element: NumericType, Device: DeviceType> {
     ///   - tensors: Tensors to differentiate for
     ///   - retainGraph: Whether to store the graph for the backwards pass. If enabled, higher order gradients can be computed.
     public func gradients(of tensors: [Self], retainBackwardsGraph retainGraph: Bool = false) -> [Self] {
-        OperationGroup.push("Backpropagate")
-        
-        // self is the result of a function, which is differentiated with respect to the given tensors.
-        let result = self
-        
-        // Build the gradient tape. Each operation is represented on the tape by its result.
-        // It is not possible to just recursively walk through the compute graph, as the graph is not a tree.
-        // Therefore, some variables may be included in multiple operations. Backpropagating through each path
-        // could therefore lead to a combinatorial explosion.
-        let operationOrder = Tensor.operationOrder(from: result)
-        
-        // The derivative of the function wrt. itself is 1.
-        var grads: [UInt64: Tensor<Element, Device>] = [
-            result.backpropID: Tensor(repeating: 1, shape: result.shape, requiresGradient: retainGraph)
-        ]
-        grads.reserveCapacity(operationOrder.count)
-        
-        // Perform the actual backpropagation.
-        for tensor in operationOrder.reversed() {
-            guard let grad = grads[tensor.backpropID] else {
-                continue
-            }
-            guard let ctx = tensor.context else {
-                continue
-            }
-            // Add gradients of all tensors that directly influenced the values
-            // of the current tensor to their respective accumulators.
-            // The accumulator is removed from the dictionary and consumed by the closure,
-            // to prevent extraneous copies through the CoW mechanism.
-            for i in ctx.sources.indices {
-                let src = ctx.sources[i]
-                
-                guard src.requiresGradient else {
+        OperationGroup.capture(named: "Backpropagate") {
+            // self is the result of a function, which is differentiated with respect to the given tensors.
+            let result = self
+            
+            // Build the gradient tape. Each operation is represented on the tape by its result.
+            // It is not possible to just recursively walk through the compute graph, as the graph is not a tree.
+            // Therefore, some variables may be included in multiple operations. Backpropagating through each path
+            // could therefore lead to a combinatorial explosion.
+            let operationOrder = Tensor.operationOrder(from: result)
+            
+            // The derivative of the function wrt. itself is 1.
+            var grads: [UInt64: Tensor<Element, Device>] = [
+                result.backpropID: Tensor(repeating: 1, shape: result.shape, requiresGradient: retainGraph)
+            ]
+            grads.reserveCapacity(operationOrder.count)
+            
+            // Perform the actual backpropagation.
+            for tensor in operationOrder.reversed() {
+                guard let grad = grads[tensor.backpropID] else {
                     continue
                 }
-                
-                let accumulator = ctx.backpropagate[i](grad, grads.removeValue(forKey: src.backpropID))
-                #if DEBUG
-                assert(accumulator.shape == src.shape)
-                #endif
-                
-                if retainGraph {
-                    grads[src.backpropID] = accumulator
-                } else {
-                    grads[src.backpropID] = accumulator.detached()
+                guard let ctx = tensor.context else {
+                    continue
+                }
+                // Add gradients of all tensors that directly influenced the values
+                // of the current tensor to their respective accumulators.
+                // The accumulator is removed from the dictionary and consumed by the closure,
+                // to prevent extraneous copies through the CoW mechanism.
+                switch ctx.backpropagate {
+                case .perSource(let backpropagate):
+                    for i in ctx.sources.indices {
+                        let src = ctx.sources[i]
+                        
+                        guard src.requiresGradient else {
+                            continue
+                        }
+                        
+                        let accumulator = backpropagate[i](grad, grads.removeValue(forKey: src.backpropID))
+#if DEBUG
+                        assert(accumulator.shape == src.shape)
+#endif
+                        
+                        if retainGraph {
+                            grads[src.backpropID] = accumulator
+                        } else {
+                            grads[src.backpropID] = accumulator.detached()
+                        }
+                    }
+                case .allSources(let backpropagate):
+                    let accumulators = ctx.sources.map { src in
+                        src.requiresGradient ? grads.removeValue(forKey: src.backpropID) : nil
+                    }
+                    var accumulated = backpropagate(grad, consume accumulators).map(Optional.some)
+                    precondition(accumulated.count == ctx.sources.count, "Backpropagation must return one gradient per source.")
+                    
+                    for i in ctx.sources.indices {
+                        let src = ctx.sources[i]
+                        
+                        // Taking the gradient out of the array leaves it uniquely referenced.
+                        guard src.requiresGradient, var accumulator = accumulated[i].take() else {
+                            continue
+                        }
+#if DEBUG
+                        assert(accumulator.shape == src.shape)
+#endif
+                        
+                        // The same tensor can be a source more than once. Its accumulator was handed to the closure
+                        // in the first position only, so the gradients of the other positions are added here.
+                        if let previous = grads.removeValue(forKey: src.backpropID) {
+                            accumulator = previous + accumulator
+                        }
+                        
+                        if retainGraph {
+                            grads[src.backpropID] = accumulator
+                        } else {
+                            grads[src.backpropID] = accumulator.detached()
+                        }
+                    }
                 }
             }
+            
+            return tensors.map {
+                grads[$0.backpropID] ?? Tensor(repeating: 0, shape: $0.shape)
+            }
         }
-        
-        let targetGrads = tensors.map {
-            grads[$0.backpropID] ?? Tensor(repeating: 0, shape: $0.shape)
-        }
-        
-        OperationGroup.pop()
-        return targetGrads
     }
     
     /// Ensures storage is not shared with other tensors.

--- a/Sources/DL4S/Tensor/TensorExt.swift
+++ b/Sources/DL4S/Tensor/TensorExt.swift
@@ -172,8 +172,18 @@ public extension Tensor where Element: RandomizableType {
     ///   - shape: Shape of the tensor, must be two dimensional
     ///   - requiresGradient: Whether it is desired to compute gradients of the tensor.
     init(xavierNormalWithShape shape: [Int], requiresGradient: Bool = false) {
+        var generator = WyHash()
+        self.init(xavierNormalWithShape: shape, requiresGradient: requiresGradient, using: &generator)
+    }
+    
+    /// Creates a tensor and fills it with random values from the given generator, sampled from a normal distribution with mean 0 and standard deviation `sqrt(2 / shape[0])`.
+    /// - Parameters:
+    ///   - shape: Shape of the tensor, must be two dimensional
+    ///   - requiresGradient: Whether it is desired to compute gradients of the tensor.
+    ///   - generator: Random number generator that provides the values.
+    init<Generator: RandomNumberGenerator>(xavierNormalWithShape shape: [Int], requiresGradient: Bool = false, using generator: inout Generator) {
         precondition(shape.count == 2, "Shape must be 2-dimensional")
-        self.init(normalDistributedWithShape: shape, mean: 0, stdev: (2 / Element(shape[0])).sqrt(), requiresGradient: requiresGradient)
+        self.init(normalDistributedWithShape: shape, mean: 0, stdev: (2 / Element(shape[0])).sqrt(), requiresGradient: requiresGradient, using: &generator)
     }
     
     /// Creates a tensor and fills it with random values sampled from a normal distribution with mean 0 and standard deviation `sqrt(2 / shape[0])`.
@@ -191,8 +201,20 @@ public extension Tensor where Element: RandomizableType {
     ///   - stdev: Standard deviation of the normal distribution
     ///   - requiresGradient: Whether it is desired to compute gradients of the tensor.
     init(normalDistributedWithShape shape: [Int], mean: Element = 0, stdev: Element = 1, requiresGradient: Bool = false) {
+        var generator = WyHash()
+        self.init(normalDistributedWithShape: shape, mean: mean, stdev: stdev, requiresGradient: requiresGradient, using: &generator)
+    }
+    
+    /// Creates a tensor and fills it with random values from the given generator, sampled from a normal distribution with the given mean and variance.
+    /// - Parameters:
+    ///   - shape: Shape of the tensor
+    ///   - mean: Mean of the normal distribution.
+    ///   - stdev: Standard deviation of the normal distribution
+    ///   - requiresGradient: Whether it is desired to compute gradients of the tensor.
+    ///   - generator: Random number generator that provides the values.
+    init<Generator: RandomNumberGenerator>(normalDistributedWithShape shape: [Int], mean: Element = 0, stdev: Element = 1, requiresGradient: Bool = false, using generator: inout Generator) {
         self.init(repeating: 0, shape: shape, requiresGradient: requiresGradient)
-        Random.fillNormal(self.values, mean: mean, stdev: stdev)
+        Random.fillNormal(self.values, mean: mean, stdev: stdev, using: &generator)
     }
     
     /// Creates a tensor and fills it with random values sampled from a normal distribution with the given mean and variance.
@@ -212,8 +234,20 @@ public extension Tensor where Element: RandomizableType {
     ///   - max: Maximum value of the uniform distribution
     ///   - requiresGradient: Whether it is desired to compute gradients of the tensor.
     init(uniformlyDistributedWithShape shape: [Int], min: Element = 0, max: Element = 1, requiresGradient: Bool = false) {
+        var generator = WyHash()
+        self.init(uniformlyDistributedWithShape: shape, min: min, max: max, requiresGradient: requiresGradient, using: &generator)
+    }
+    
+    /// Creates a tensor and fills it with random values from the given generator, sampled from a uniform distribution with the given minimum and maximum.
+    /// - Parameters:
+    ///   - shape: Shape of the tensor
+    ///   - min: Minimum value of the uniform distribution
+    ///   - max: Maximum value of the uniform distribution
+    ///   - requiresGradient: Whether it is desired to compute gradients of the tensor.
+    ///   - generator: Random number generator that provides the values.
+    init<Generator: RandomNumberGenerator>(uniformlyDistributedWithShape shape: [Int], min: Element = 0, max: Element = 1, requiresGradient: Bool = false, using generator: inout Generator) {
         self.init(repeating: 0, shape: shape, requiresGradient: requiresGradient)
-        Random.fill(self.values, a: min, b: max)
+        Random.fill(self.values, a: min, b: max, using: &generator)
     }
     
     /// Creates a tensor and fills it with random values sampled from a uniform distribution with the given minimum and maximum.
@@ -228,11 +262,32 @@ public extension Tensor where Element: RandomizableType {
 }
 
 public extension Tensor {
+    /// Creates a tensor of ones and zeros, where each element is 1 with the given probability.
+    /// - Parameters:
+    ///   - shape: Shape of the tensor
+    ///   - probability: Probability of a 1
+    ///   - requiresGradient: Whether it is desired to compute gradients of the tensor.
     init(bernoulliDistributedWithShape shape: [Int], probability: Float, requiresGradient: Bool = false) {
-        self.init(repeating: 0, shape: shape, requiresGradient: requiresGradient)
-        Random.bernoulli(values, p: probability)
+        var generator = WyHash()
+        self.init(bernoulliDistributedWithShape: shape, probability: probability, requiresGradient: requiresGradient, using: &generator)
     }
     
+    /// Creates a tensor of ones and zeros from the given generator, where each element is 1 with the given probability.
+    /// - Parameters:
+    ///   - shape: Shape of the tensor
+    ///   - probability: Probability of a 1
+    ///   - requiresGradient: Whether it is desired to compute gradients of the tensor.
+    ///   - generator: Random number generator that provides the values.
+    init<Generator: RandomNumberGenerator>(bernoulliDistributedWithShape shape: [Int], probability: Float, requiresGradient: Bool = false, using generator: inout Generator) {
+        self.init(repeating: 0, shape: shape, requiresGradient: requiresGradient)
+        Random.bernoulli(values, p: probability, using: &generator)
+    }
+    
+    /// Creates a tensor of ones and zeros, where each element is 1 with the given probability.
+    /// - Parameters:
+    ///   - shape: Shape of the tensor
+    ///   - probability: Probability of a 1
+    ///   - requiresGradient: Whether it is desired to compute gradients of the tensor.
     init(bernoulliDistributedWithShape shape: Int..., probability: Float, requiresGradient: Bool = false) {
         self.init(bernoulliDistributedWithShape: shape, probability: probability, requiresGradient: requiresGradient)
     }

--- a/Sources/DL4S/Tensor/TensorExt.swift
+++ b/Sources/DL4S/Tensor/TensorExt.swift
@@ -214,7 +214,7 @@ public extension Tensor where Element: RandomizableType {
     ///   - generator: Random number generator that provides the values.
     init<Generator: RandomNumberGenerator>(normalDistributedWithShape shape: [Int], mean: Element = 0, stdev: Element = 1, requiresGradient: Bool = false, using generator: inout Generator) {
         self.init(repeating: 0, shape: shape, requiresGradient: requiresGradient)
-        Random.fillNormal(self.values, mean: mean, stdev: stdev, using: &generator)
+        Random.fillNormal(self.mutableValues, mean: mean, stdev: stdev, using: &generator)
     }
     
     /// Creates a tensor and fills it with random values sampled from a normal distribution with the given mean and variance.
@@ -247,7 +247,7 @@ public extension Tensor where Element: RandomizableType {
     ///   - generator: Random number generator that provides the values.
     init<Generator: RandomNumberGenerator>(uniformlyDistributedWithShape shape: [Int], min: Element = 0, max: Element = 1, requiresGradient: Bool = false, using generator: inout Generator) {
         self.init(repeating: 0, shape: shape, requiresGradient: requiresGradient)
-        Random.fill(self.values, a: min, b: max, using: &generator)
+        Random.fill(self.mutableValues, a: min, b: max, using: &generator)
     }
     
     /// Creates a tensor and fills it with random values sampled from a uniform distribution with the given minimum and maximum.
@@ -280,7 +280,7 @@ public extension Tensor {
     ///   - generator: Random number generator that provides the values.
     init<Generator: RandomNumberGenerator>(bernoulliDistributedWithShape shape: [Int], probability: Float, requiresGradient: Bool = false, using generator: inout Generator) {
         self.init(repeating: 0, shape: shape, requiresGradient: requiresGradient)
-        Random.bernoulli(values, p: probability, using: &generator)
+        Random.bernoulli(mutableValues, p: probability, using: &generator)
     }
     
     /// Creates a tensor of ones and zeros, where each element is 1 with the given probability.

--- a/Sources/DL4S/Util.swift
+++ b/Sources/DL4S/Util.swift
@@ -319,23 +319,3 @@ struct File: Sequence {
         return LineIterator(handle: try? FileHandle(forReadingFrom: self.url))
     }
 }
-
-@propertyWrapper
-struct ThreadLocal<Value> {
-    private var initialValue: Value
-    private var key: UInt64
-    
-    var wrappedValue: Value {
-        get {
-            return (Thread.current.threadDictionary[key] as? Value) ?? initialValue
-        }
-        set {
-            Thread.current.threadDictionary[key] = newValue
-        }
-    }
-    
-    init(wrappedValue: Value) {
-        self.initialValue = wrappedValue
-        self.key = UInt64.random(in: 0 ... UInt64.max)
-    }
-}

--- a/Tests/DL4STests/AllocationTests.swift
+++ b/Tests/DL4STests/AllocationTests.swift
@@ -1,0 +1,103 @@
+//
+//  AllocationTests.swift
+//  DL4S
+//
+//  Created by Palle Klewitz on 03.09.26.
+//  Copyright (c) 2026 - Palle Klewitz
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import XCTest
+import DL4S
+
+
+class AllocationTests: XCTestCase {
+    /// Micro-benchmark: a loop over small-tensor operations.
+    func testSmallTensorOperationThroughput() throws {
+        try skipUnlessLongTestsEnabled()
+        
+        let a = Tensor<Float, CPU>((0 ..< 64).map(Float.init), shape: [8, 8])
+        let b = Tensor<Float, CPU>(repeating: 0.5, shape: [8, 8])
+        
+        measure {
+            for _ in 0 ..< 100_000 {
+                _ = (a * b + a).reduceSum(along: [1])[0].item
+            }
+        }
+    }
+    
+    /// Macro-benchmark: MNIST training steps on a dense network.
+    func testMNISTDenseTrainingThroughput() throws {
+        try skipUnlessLongTestsEnabled()
+        
+        let ((images, labels), _) = MNISTTests.loadMNIST(type: Float.self, device: CPU.self)
+        let batchSize = 256
+        let model = Sequential {
+            Dense<Float, CPU>(inputSize: 28 * 28, outputSize: 500)
+            Relu<Float, CPU>()
+            Dense<Float, CPU>(inputSize: 500, outputSize: 300)
+            Relu<Float, CPU>()
+            Dense<Float, CPU>(inputSize: 300, outputSize: 10)
+            LogSoftmax<Float, CPU>()
+        }
+        var optimizer = Adam(model: model, learningRate: 0.001)
+        
+        measure {
+            for _ in 0 ..< 20 {
+                let (input, target) = Random.minibatch(from: images, labels: labels, count: batchSize)
+                let predicted = optimizer.model(input.view(as: [batchSize, 28 * 28]))
+                let loss = categoricalNegativeLogLikelihood(expected: target, actual: predicted)
+                optimizer.update(along: loss.gradients(of: optimizer.model.parameters))
+            }
+        }
+    }
+    
+    /// Macro-benchmark: MNIST training steps on a CNN.
+    func testMNISTConvTrainingThroughput() throws {
+        try skipUnlessLongTestsEnabled()
+        
+        let ((images, labels), _) = MNISTTests.loadMNIST(type: Float.self, device: CPU.self)
+        let batchSize = 256
+        let model = Sequential {
+            Convolution2D<Float, CPU>(inputChannels: 1, outputChannels: 6, kernelSize: (5, 5), padding: 0)
+            LayerNorm<Float, CPU>(inputSize: [6, 24, 24])
+            Relu<Float, CPU>()
+            MaxPool2D<Float, CPU>(windowSize: 2, stride: 2)
+            Convolution2D<Float, CPU>(inputChannels: 6, outputChannels: 16, kernelSize: (5, 5), padding: 0)
+            LayerNorm<Float, CPU>(inputSize: [16, 8, 8])
+            Relu<Float, CPU>()
+            MaxPool2D<Float, CPU>(windowSize: 2, stride: 2)
+            Flatten<Float, CPU>()
+            Dense<Float, CPU>(inputSize: 16 * 4 * 4, outputSize: 120)
+            Relu<Float, CPU>()
+            Dense<Float, CPU>(inputSize: 120, outputSize: 10)
+            LogSoftmax<Float, CPU>()
+        }
+        var optimizer = Adam(model: model, learningRate: 0.001)
+        
+        measure {
+            for _ in 0 ..< 5 {
+                let (input, target) = Random.minibatch(from: images, labels: labels, count: batchSize)
+                let predicted = optimizer.model(input.view(as: [batchSize, 1, 28, 28]))
+                let loss = categoricalNegativeLogLikelihood(expected: target, actual: predicted)
+                optimizer.update(along: loss.gradients(of: optimizer.model.parameters))
+            }
+        }
+    }
+}

--- a/Tests/DL4STests/ConcurrencyTests.swift
+++ b/Tests/DL4STests/ConcurrencyTests.swift
@@ -66,25 +66,6 @@ final class ConcurrencyTests: XCTestCase {
         group.wait()
     }
     
-    /// Runs `body` and records known concurrency failures as expected failures.
-    private func runExpectingKnownConcurrencyFailure(_ body: () throws -> Void) throws {
-        // TODO: Remove this wrapper when concurrency fixes are implemented.
-        // On Darwin, XCTest marks the failures as expected and the test does not break CI.
-        // On Linux, `XCTExpectFailure` does not exist, so the test is skipped unless
-        // `DL4S_CONCURRENCY_TESTS=1` is set.
-        #if canImport(ObjectiveC)
-        try XCTExpectFailure("Failure is expected until concurrency fixes are implemented", options: .nonStrict()) {
-            try body()
-        }
-        #else
-        try XCTSkipIf(
-            ProcessInfo.processInfo.environment["DL4S_CONCURRENCY_TESTS"] == nil,
-            "Failure is expected until concurrency fixes are implemented"
-        )
-        try body()
-        #endif
-    }
-    
     private typealias DenseTanh = Sequential<Dense<Float, CPU>, Tanh<Float, CPU>>
     private typealias TrainedModel = Sequential<Sequential<DenseTanh, DenseTanh>, Sequential<Dense<Float, CPU>, Sigmoid<Float, CPU>>>
     
@@ -126,39 +107,34 @@ final class ConcurrencyTests: XCTestCase {
     /// Parallel inference on shared model
     ///
     /// Every result must be exactly equal to a result that was computed in main. Inference has no random component, so a tolerance is not needed and would hide errors.
-    ///
-    /// Values are correct, but the thread sanitizer reports an access race on `OperationGroup.operationStack`.
-    /// The  mutating`@ThreadLocal` setter is a write access on shared state.
     func testConcurrentInferenceMatchesSerialReference() throws {
         let model = makeTrainedModel()
         let input = Tensor<Float, CPU>(uniformlyDistributedWithShape: [256, 2], min: 0, max: 1)
         let reference = model(input).elements
         let iterations = 50
         
-        try runExpectingKnownConcurrencyFailure {
-            for threadCount in threadCounts {
-                let mismatches = ThreadSafeCollector<String>()
-                
-                run(threadCount: threadCount) { threadIndex in
-                    for iteration in 0 ..< iterations {
-                        let result = model(input).elements
-                        if result != reference {
-                            let firstDifference = zip(result, reference).enumerated().first { $0.element.0 != $0.element.1 }
-                            mismatches.append(
-                                "thread \(threadIndex), iteration \(iteration), first difference at element \(firstDifference?.offset ?? -1)"
-                            )
-                        }
+        for threadCount in threadCounts {
+            let mismatches = ThreadSafeCollector<String>()
+            
+            run(threadCount: threadCount) { threadIndex in
+                for iteration in 0 ..< iterations {
+                    let result = model(input).elements
+                    if result != reference {
+                        let firstDifference = zip(result, reference).enumerated().first { $0.element.0 != $0.element.1 }
+                        mismatches.append(
+                            "thread \(threadIndex), iteration \(iteration), first difference at element \(firstDifference?.offset ?? -1)"
+                        )
                     }
                 }
-                
-                let collected = mismatches.values
-                XCTAssertEqual(
-                    collected.count, 0,
-                    "\(collected.count) of \(threadCount * iterations) results with \(threadCount) threads differ from reference. First: \(collected.first ?? "none")"
-                )
             }
+                
+            let collected = mismatches.values
+            XCTAssertEqual(
+                collected.count, 0,
+                "\(collected.count) of \(threadCount * iterations) results with \(threadCount) threads differ from reference. First: \(collected.first ?? "none")"
+            )
         }
-    }
+}
     
     /// Dropout layer randomness stress test.
     ///
@@ -225,4 +201,83 @@ final class ConcurrencyTests: XCTestCase {
             XCTAssertFalse(model.contains(where: { $0.isNaN }), "Model \(index) contains NaN weights.")
         }
     }
+    
+    /// Parallel backpropagation through one shared stack node.
+    ///
+    /// The stacked tensor is created once and every thread differentiates its own loss through it.
+    /// The gradients must be exactly equal to the gradients that were computed in main.
+    func testConcurrentBackpropagationThroughSharedStackNode() throws {
+        let a = Tensor<Float, CPU>(uniformlyDistributedWithShape: [64, 32], requiresGradient: true)
+        let b = Tensor<Float, CPU>(uniformlyDistributedWithShape: [64, 32], requiresGradient: true)
+        let stacked = stack([a, b])
+        let iterations = 50
+        
+        func backwardPass() -> [[Float]] {
+            (stacked * stacked).reduceSum().gradients(of: [a, b]).map { $0.elements }
+        }
+        let reference = backwardPass()
+        
+        for threadCount in threadCounts {
+            let mismatches = ThreadSafeCollector<String>()
+            
+            run(threadCount: threadCount) { threadIndex in
+                for iteration in 0 ..< iterations {
+                    if backwardPass() != reference {
+                        mismatches.append("thread \(threadIndex), iteration \(iteration)")
+                    }
+                }
+            }
+            
+            let collected = mismatches.values
+            XCTAssertEqual(
+                collected.count, 0,
+                "\(collected.count) of \(threadCount * iterations) gradients with \(threadCount) threads differ from reference. First: \(collected.first ?? "none")"
+            )
+        }
+    }
+    
+    #if DL4S_TRACE_ALLOCATIONS
+    /// Parallel allocate and free while allocation tracing is switched on and off.
+    ///
+    /// Compile the tests with `-Xswiftc -DDL4S_TRACE_ALLOCATIONS` to include this test.
+    func testConcurrentAllocationTracing() throws {
+        let threadCount = 8
+        let iterations = 200
+        
+        CPUMemoryOperators.setAllocationTracing(true)
+        defer {
+            CPUMemoryOperators.setAllocationTracing(false)
+        }
+        
+        run(threadCount: threadCount) { threadIndex in
+            for iteration in 0 ..< iterations {
+                let tensor = Tensor<Float, CPU>(repeating: Float(iteration), shape: [16, 16])
+                XCTAssertEqual((tensor + tensor).elements.first, Float(iteration) * 2)
+                
+                // The first thread switches tracing on and off while the other threads allocate and free.
+                if threadIndex == 0 && iteration % 25 == 0 {
+                    CPUMemoryOperators.setAllocationTracing(iteration % 50 == 0)
+                }
+            }
+        }
+        
+        // With tracing switched on, one allocation is recorded and its record is removed by free.
+        CPUMemoryOperators.setAllocationTracing(true)
+        XCTAssertEqual(CPUMemoryOperators.tracedAllocationCount, 0)
+        do {
+            let tensor = Tensor<Float, CPU>(repeating: 1, shape: [4])
+            withExtendedLifetime(tensor) {
+                XCTAssertEqual(CPUMemoryOperators.tracedAllocationCount, 1)
+            }
+        }
+        XCTAssertEqual(CPUMemoryOperators.tracedAllocationCount, 0)
+        
+        // With tracing switched off, nothing is recorded.
+        CPUMemoryOperators.setAllocationTracing(false)
+        let tensor = Tensor<Float, CPU>(repeating: 1, shape: [4])
+        withExtendedLifetime(tensor) {
+            XCTAssertEqual(CPUMemoryOperators.tracedAllocationCount, 0)
+        }
+    }
+    #endif
 }

--- a/Tests/DL4STests/ConcurrencyTests.swift
+++ b/Tests/DL4STests/ConcurrencyTests.swift
@@ -164,71 +164,65 @@ final class ConcurrencyTests: XCTestCase {
     ///
     /// The mask must only contain zeros and ones, the keep rate must be close to the configured rate, and no two passes may produce the same mask.
     ///
-    /// With a shared RNG, release builds may produce large overlap between masks.
-    /// Thread sanitizer detects a data race.
+    /// A generator that is shared between threads would produce overlapping masks.
     func testConcurrentDropoutForwardPasses() throws {
         let dropout = Dropout<Float, CPU>(rate: 0.5)
         let input = Tensor<Float, CPU>(repeating: 1, shape: [64, 64])
         let iterations = 100
         let threadCount = 8
         
-        try runExpectingKnownConcurrencyFailure {
-            let invalidMasks = ThreadSafeCollector<String>()
-            let masks = ThreadSafeCollector<[Float]>()
-            
-            run(threadCount: threadCount) { threadIndex in
-                for iteration in 0 ..< iterations {
-                    let mask = dropout(input).elements
-                    if mask.contains(where: { $0 != 0 && $0 != 1 }) {
-                        invalidMasks.append("thread \(threadIndex), iteration \(iteration)")
-                    }
-                    masks.append(mask)
+        let invalidMasks = ThreadSafeCollector<String>()
+        let masks = ThreadSafeCollector<[Float]>()
+        
+        run(threadCount: threadCount) { threadIndex in
+            for iteration in 0 ..< iterations {
+                let mask = dropout(input).elements
+                if mask.contains(where: { $0 != 0 && $0 != 1 }) {
+                    invalidMasks.append("thread \(threadIndex), iteration \(iteration)")
                 }
+                masks.append(mask)
             }
-            
-            let collectedMasks = masks.values
-            XCTAssertEqual(collectedMasks.count, threadCount * iterations)
-            XCTAssertEqual(invalidMasks.values.count, 0, "Dropout produced values other than 0 and 1: \(invalidMasks.values.prefix(3))")
-            
-            let keptElements = collectedMasks.reduce(0) { $0 + $1.reduce(0, +) }
-            let keepRate = keptElements / Float(collectedMasks.count * input.count)
-            XCTAssertEqual(keepRate, 0.5, accuracy: 0.02, "Keep rate over all passes deviates from the configured rate.")
-            
-            let distinctMasks = Set(collectedMasks.map { $0.map { UInt8($0) } })
-            XCTAssertEqual(distinctMasks.count, collectedMasks.count, "Some dropout passes produced identical masks.")
         }
+        
+        let collectedMasks = masks.values
+        XCTAssertEqual(collectedMasks.count, threadCount * iterations)
+        XCTAssertEqual(invalidMasks.values.count, 0, "Dropout produced values other than 0 and 1: \(invalidMasks.values.prefix(3))")
+        
+        let keptElements = collectedMasks.reduce(0) { $0 + $1.reduce(0, +) }
+        let keepRate = keptElements / Float(collectedMasks.count * input.count)
+        XCTAssertEqual(keepRate, 0.5, accuracy: 0.02, "Keep rate over all passes deviates from the configured rate.")
+        
+        let distinctMasks = Set(collectedMasks.map { $0.map { UInt8($0) } })
+        XCTAssertEqual(distinctMasks.count, collectedMasks.count, "Some dropout passes produced identical masks.")
     }
     
     /// Weight initialization stress test
     ///
     /// Weights of one model must be independent of another model initialized in parallel.
-    /// This fails with the shared mutable state of the RNG.
     func testConcurrentWeightInitializationProducesIndependentWeights() throws {
         let threadCount = 8
         let layerSize = 128
         
-        try runExpectingKnownConcurrencyFailure {
-            let weights = ThreadSafeCollector<[Double]>()
-            
-            run(threadCount: threadCount) { _ in
-                let layer = Dense<Double, CPU>(inputSize: layerSize, outputSize: layerSize)
-                weights.append(layer.weights.elements)
-            }
-            
-            let collected = weights.values
-            XCTAssertEqual(collected.count, threadCount)
-            
-            let allValues = collected.flatMap { $0 }
-            let duplicateCount = allValues.count - Set(allValues).count
-            let duplicateFraction = Double(duplicateCount) / Double(allValues.count)
-            XCTAssertLessThan(
-                duplicateFraction, 0.001,
-                "\(duplicateCount) of \(allValues.count) weights are duplicates across \(threadCount) independently initialized models."
-            )
-            
-            for (index, model) in collected.enumerated() {
-                XCTAssertFalse(model.contains(where: { $0.isNaN }), "Model \(index) contains NaN weights.")
-            }
+        let weights = ThreadSafeCollector<[Double]>()
+        
+        run(threadCount: threadCount) { _ in
+            let layer = Dense<Double, CPU>(inputSize: layerSize, outputSize: layerSize)
+            weights.append(layer.weights.elements)
+        }
+        
+        let collected = weights.values
+        XCTAssertEqual(collected.count, threadCount)
+        
+        let allValues = collected.flatMap { $0 }
+        let duplicateCount = allValues.count - Set(allValues).count
+        let duplicateFraction = Double(duplicateCount) / Double(allValues.count)
+        XCTAssertLessThan(
+            duplicateFraction, 0.001,
+            "\(duplicateCount) of \(allValues.count) weights are duplicates across \(threadCount) independently initialized models."
+        )
+        
+        for (index, model) in collected.enumerated() {
+            XCTAssertFalse(model.contains(where: { $0.isNaN }), "Model \(index) contains NaN weights.")
         }
     }
 }

--- a/Tests/DL4STests/ConcurrencyTests.swift
+++ b/Tests/DL4STests/ConcurrencyTests.swift
@@ -1,0 +1,234 @@
+//
+//  ConcurrencyTests.swift
+//  DL4STests
+//
+//  Created by Palle Klewitz on 01.09.26.
+//  Copyright (c) 2026 - Palle Klewitz
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import XCTest
+import DL4S
+
+/// Collects values from several threads behind a lock.
+private final class ThreadSafeCollector<Value> {
+    private var storage: [Value] = []
+    private let lock = NSLock()
+    
+    func append(_ value: Value) {
+        lock.lock()
+        storage.append(value)
+        lock.unlock()
+    }
+    
+    var values: [Value] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}
+
+/// Stress tests that run DL4S with several threads at the same time.
+///
+/// Run the suite with `swift test --filter Concurrency`.
+/// Run it under the thread sanitizer with `swift test --sanitize=thread --filter Concurrency`.
+final class ConcurrencyTests: XCTestCase {
+    private let threadCounts = [2, 4, 8]
+    
+    private func run(threadCount: Int, _ body: @escaping (_ threadIndex: Int) -> Void) {
+        let group = DispatchGroup()
+        for index in 0 ..< threadCount {
+            group.enter()
+            // raw Threads ensure parallel execution, as opposed to structured concurrency or dispatch queues.
+            let thread = Thread {
+                body(index)
+                group.leave()
+            }
+            thread.name = "DL4S.ConcurrencyTests.\(index)"
+            thread.start()
+        }
+        group.wait()
+    }
+    
+    /// Runs `body` and records known concurrency failures as expected failures.
+    private func runExpectingKnownConcurrencyFailure(_ body: () throws -> Void) throws {
+        // TODO: Remove this wrapper when concurrency fixes are implemented.
+        // On Darwin, XCTest marks the failures as expected and the test does not break CI.
+        // On Linux, `XCTExpectFailure` does not exist, so the test is skipped unless
+        // `DL4S_CONCURRENCY_TESTS=1` is set.
+        #if canImport(ObjectiveC)
+        try XCTExpectFailure("Failure is expected until concurrency fixes are implemented", options: .nonStrict()) {
+            try body()
+        }
+        #else
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["DL4S_CONCURRENCY_TESTS"] == nil,
+            "Failure is expected until concurrency fixes are implemented"
+        )
+        try body()
+        #endif
+    }
+    
+    private typealias DenseTanh = Sequential<Dense<Float, CPU>, Tanh<Float, CPU>>
+    private typealias TrainedModel = Sequential<Sequential<DenseTanh, DenseTanh>, Sequential<Dense<Float, CPU>, Sigmoid<Float, CPU>>>
+    
+    /// Trains a small model on the XOR problem so the test has a model with initialized weights.
+    private func makeTrainedModel() -> TrainedModel {
+        let inputs = Tensor<Float, CPU>([
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [1, 1]
+        ])
+        let expected = Tensor<Float, CPU>([
+            [0],
+            [1],
+            [1],
+            [0]
+        ])
+        
+        let model = Sequential {
+            Dense<Float, CPU>(inputSize: 2, outputSize: 64)
+            Tanh<Float, CPU>()
+            Dense<Float, CPU>(inputSize: 64, outputSize: 64)
+            Tanh<Float, CPU>()
+            Dense<Float, CPU>(inputSize: 64, outputSize: 1)
+            Sigmoid<Float, CPU>()
+        }
+        var optimizer = Adam(model: model, learningRate: 0.05)
+        
+        for _ in 1 ... 50 {
+            let prediction = optimizer.model(inputs)
+            let loss = binaryCrossEntropy(expected: expected, actual: prediction)
+            let gradients = loss.gradients(of: optimizer.model.parameters)
+            optimizer.update(along: gradients)
+        }
+        
+        return optimizer.model
+    }
+    
+    /// Parallel inference on shared model
+    ///
+    /// Every result must be exactly equal to a result that was computed in main. Inference has no random component, so a tolerance is not needed and would hide errors.
+    ///
+    /// Values are correct, but the thread sanitizer reports an access race on `OperationGroup.operationStack`.
+    /// The  mutating`@ThreadLocal` setter is a write access on shared state.
+    func testConcurrentInferenceMatchesSerialReference() throws {
+        let model = makeTrainedModel()
+        let input = Tensor<Float, CPU>(uniformlyDistributedWithShape: [256, 2], min: 0, max: 1)
+        let reference = model(input).elements
+        let iterations = 50
+        
+        try runExpectingKnownConcurrencyFailure {
+            for threadCount in threadCounts {
+                let mismatches = ThreadSafeCollector<String>()
+                
+                run(threadCount: threadCount) { threadIndex in
+                    for iteration in 0 ..< iterations {
+                        let result = model(input).elements
+                        if result != reference {
+                            let firstDifference = zip(result, reference).enumerated().first { $0.element.0 != $0.element.1 }
+                            mismatches.append(
+                                "thread \(threadIndex), iteration \(iteration), first difference at element \(firstDifference?.offset ?? -1)"
+                            )
+                        }
+                    }
+                }
+                
+                let collected = mismatches.values
+                XCTAssertEqual(
+                    collected.count, 0,
+                    "\(collected.count) of \(threadCount * iterations) results with \(threadCount) threads differ from reference. First: \(collected.first ?? "none")"
+                )
+            }
+        }
+    }
+    
+    /// Dropout layer randomness stress test.
+    ///
+    /// The mask must only contain zeros and ones, the keep rate must be close to the configured rate, and no two passes may produce the same mask.
+    ///
+    /// With a shared RNG, release builds may produce large overlap between masks.
+    /// Thread sanitizer detects a data race.
+    func testConcurrentDropoutForwardPasses() throws {
+        let dropout = Dropout<Float, CPU>(rate: 0.5)
+        let input = Tensor<Float, CPU>(repeating: 1, shape: [64, 64])
+        let iterations = 100
+        let threadCount = 8
+        
+        try runExpectingKnownConcurrencyFailure {
+            let invalidMasks = ThreadSafeCollector<String>()
+            let masks = ThreadSafeCollector<[Float]>()
+            
+            run(threadCount: threadCount) { threadIndex in
+                for iteration in 0 ..< iterations {
+                    let mask = dropout(input).elements
+                    if mask.contains(where: { $0 != 0 && $0 != 1 }) {
+                        invalidMasks.append("thread \(threadIndex), iteration \(iteration)")
+                    }
+                    masks.append(mask)
+                }
+            }
+            
+            let collectedMasks = masks.values
+            XCTAssertEqual(collectedMasks.count, threadCount * iterations)
+            XCTAssertEqual(invalidMasks.values.count, 0, "Dropout produced values other than 0 and 1: \(invalidMasks.values.prefix(3))")
+            
+            let keptElements = collectedMasks.reduce(0) { $0 + $1.reduce(0, +) }
+            let keepRate = keptElements / Float(collectedMasks.count * input.count)
+            XCTAssertEqual(keepRate, 0.5, accuracy: 0.02, "Keep rate over all passes deviates from the configured rate.")
+            
+            let distinctMasks = Set(collectedMasks.map { $0.map { UInt8($0) } })
+            XCTAssertEqual(distinctMasks.count, collectedMasks.count, "Some dropout passes produced identical masks.")
+        }
+    }
+    
+    /// Weight initialization stress test
+    ///
+    /// Weights of one model must be independent of another model initialized in parallel.
+    /// This fails with the shared mutable state of the RNG.
+    func testConcurrentWeightInitializationProducesIndependentWeights() throws {
+        let threadCount = 8
+        let layerSize = 128
+        
+        try runExpectingKnownConcurrencyFailure {
+            let weights = ThreadSafeCollector<[Double]>()
+            
+            run(threadCount: threadCount) { _ in
+                let layer = Dense<Double, CPU>(inputSize: layerSize, outputSize: layerSize)
+                weights.append(layer.weights.elements)
+            }
+            
+            let collected = weights.values
+            XCTAssertEqual(collected.count, threadCount)
+            
+            let allValues = collected.flatMap { $0 }
+            let duplicateCount = allValues.count - Set(allValues).count
+            let duplicateFraction = Double(duplicateCount) / Double(allValues.count)
+            XCTAssertLessThan(
+                duplicateFraction, 0.001,
+                "\(duplicateCount) of \(allValues.count) weights are duplicates across \(threadCount) independently initialized models."
+            )
+            
+            for (index, model) in collected.enumerated() {
+                XCTAssertFalse(model.contains(where: { $0.isNaN }), "Model \(index) contains NaN weights.")
+            }
+        }
+    }
+}

--- a/Tests/DL4STests/EngineV2Tests.swift
+++ b/Tests/DL4STests/EngineV2Tests.swift
@@ -46,7 +46,7 @@ class EngineV2Tests: XCTestCase {
             0, 0, 0,
             0, 0, 0
         ]
-        XCTAssertEqual(result.values.array, expected)
+        XCTAssertEqual(Buffer(result.values).array, expected)
     }
 
     func testBroadcast1() {
@@ -74,9 +74,9 @@ class EngineV2Tests: XCTestCase {
         let lhs = Tensor<Float, CPU>([[1,2],[3,4],[5,6]])
         let rhs = Tensor<Float, CPU>([1,2,3]).view(as: -1, 1)
         
-        let result = Tensor<Float, CPU>(repeating: 0, shape: 3, 2)
+        var result = Tensor<Float, CPU>(repeating: 0, shape: 3, 2)
         
-        CPUEngine.broadcastAdd(lhs: lhs.values, rhs: rhs.values, result: result.values)
+        CPUEngine.broadcastAdd(lhs: lhs.values, rhs: rhs.values, result: result.mutableValues)
         
         print(result)
     }
@@ -102,8 +102,8 @@ class EngineV2Tests: XCTestCase {
     func testReduceSum1() {
         let a = Tensor<Float, CPU>([[1,2,3,4],[5,6,7,8],[9,10,11,12],[13,14,15,16]])
         let v = a.values
-        let result = Tensor<Float, CPU>(repeating: Float(0), shape: 4)
-        let r = result.values
+        var result = Tensor<Float, CPU>(repeating: Float(0), shape: 4)
+        let r = result.mutableValues
         
         CPU.Engine.reduceSum(values: v, result: r, axis: 0)
         
@@ -113,8 +113,8 @@ class EngineV2Tests: XCTestCase {
     func testReduceSum2() {
         let a = Tensor<Float, CPU>([[1,2,3,4],[5,6,7,8],[9,10,11,12],[13,14,15,16]])
         let v = a.values
-        let result = Tensor<Float, CPU>(repeating: Float(0), shape: 4)
-        let r = result.values
+        var result = Tensor<Float, CPU>(repeating: Float(0), shape: 4)
+        let r = result.mutableValues
         
         CPU.Engine.reduceSum(values: v, result: r, axis: 1)
         
@@ -124,8 +124,8 @@ class EngineV2Tests: XCTestCase {
     func testReduceSum3() {
         let a = Tensor<Float, CPU>([[1,2,3,4],[5,6,7,8],[9,10,11,12],[13,14,15,16]])
         let v = a.values
-        let result = Tensor<Float, CPU>(repeating: Float(0), shape: [])
-        let r = result.values
+        var result = Tensor<Float, CPU>(repeating: Float(0), shape: [])
+        let r = result.mutableValues
         
         CPU.Engine.reduceSum(values: v, result: r, axes: [0, 1])
         

--- a/Tests/DL4STests/GradientTests.swift
+++ b/Tests/DL4STests/GradientTests.swift
@@ -154,7 +154,30 @@ class GradientTests: XCTestCase {
         
         let result = model(input).0.hiddenState
         let inputGrad = result.gradients(of: [input], retainBackwardsGraph: true)[0]
-        
+
         print(inputGrad.graph())
+    }
+
+    func testRepeatedSubscriptReadAccumulatesGradient() {
+        let x = Tensor<Float, CPU>([[1, 2], [3, 4]], requiresGradient: true)
+        let y = (x[0] * 2 + x[0] * 3 + x[1 ..< 2] * 4 + x[1 ..< 2] * 5).reduceSum()
+
+        XCTAssertEqual(y.gradients(of: [x])[0], Tensor([[5, 5], [9, 9]]))
+    }
+
+    /// Broadcasting reads the same weight slice once per batch element, so the weight gradient must sum over the batch.
+    func testBroadcastMatMulWeightGradientSumsOverBatch() {
+        let batchSize = 4
+        let x = Tensor<Float, CPU>(uniformlyDistributedWithShape: [batchSize, 3, 5])
+        let w = Tensor<Float, CPU>(uniformlyDistributedWithShape: [5, 2], requiresGradient: true)
+        let scale = Tensor<Float, CPU>(uniformlyDistributedWithShape: [batchSize, 3, 2])
+
+        let broadcastGrad = (x.broadcastMatrixMultiplied(with: w) * scale).reduceSum().gradients(of: [w])[0]
+        let explicitGrad = (0 ..< batchSize)
+            .map { (x[$0].matrixMultiplied(with: w) * scale[$0]).reduceSum() }
+            .reduce(Tensor(0), +)
+            .gradients(of: [w])[0]
+
+        XCTAssertLessThan(((broadcastGrad - explicitGrad) * (broadcastGrad - explicitGrad)).reduceSum().item, 1e-8)
     }
 }

--- a/Tests/DL4STests/LayerTests.swift
+++ b/Tests/DL4STests/LayerTests.swift
@@ -1,0 +1,58 @@
+//
+//  LayerTests.swift
+//  DL4STests
+//
+//  Created by Palle Klewitz on 03.09.26.
+//  Copyright (c) 2026 - Palle Klewitz
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import XCTest
+import DL4S
+
+final class LayerTests: XCTestCase {
+    private typealias TensorLayer = any LayerType<Tensor<Float, CPU>, Tensor<Float, CPU>, Float, CPU>
+    
+    /// Returns a copy of the layer with all parameters set to zero.
+    ///
+    /// The generic parameter opens the existential, so the writable key paths of the concrete layer type can be used.
+    private func zeroingParameters<Layer: LayerType>(of layer: Layer) -> Layer where Layer.Parameter == Float, Layer.Device == CPU {
+        var copy = layer
+        for path in layer.parameterPaths {
+            copy[keyPath: path] = Tensor(repeating: 0, shape: layer[keyPath: path].shape)
+        }
+        return copy
+    }
+    
+    func testExistentialLayerRunsInferenceAndCopiesIndependently() {
+        let dense = Dense<Float, CPU>(inputSize: 4, outputSize: 3)
+        let layer: TensorLayer = dense
+        let input = Tensor<Float, CPU>(uniformlyDistributedWithShape: [2, 4])
+        let expected = dense(input)
+        
+        XCTAssertEqual(layer(input), expected)
+        XCTAssertEqual(layer.parameters.count, dense.parameters.count)
+        
+        let zeroed: TensorLayer = zeroingParameters(of: layer)
+        
+        XCTAssertEqual(zeroed(input), Tensor(repeating: 0, shape: [2, 3]))
+        XCTAssertEqual(layer(input), expected)
+        XCTAssertEqual(dense(input), expected)
+    }
+}

--- a/Tests/DL4STests/OwnershipTests.swift
+++ b/Tests/DL4STests/OwnershipTests.swift
@@ -165,13 +165,39 @@ class OwnershipTests: XCTestCase {
             }
         }
     }
-}
 
-private extension OwnershipTests {
+    func testCopiedTensorKeepsBackpropID() {
+        let original = Tensor<Float, CPU>([1, 2, 3])
+        let copy = original
+        
+        XCTAssertEqual(copy.backpropID, original.backpropID)
+        XCTAssertNotEqual(Tensor<Float, CPU>([1, 2, 3]).backpropID, original.backpropID)
+    }
+    
+    func testEnsureOwnershipOnSharedBufferMintsNewBackpropID() {
+        let original = Tensor<Float, CPU>([1, 2, 3])
+        var copy = original
+        copy.ensureOwnership()
+        
+        XCTAssertNotEqual(copy.backpropID, original.backpropID)
+        XCTAssertNotEqual(copy.bufferAddress, original.bufferAddress)
+        XCTAssertEqual(copy, original)
+    }
+    
+    func testEnsureOwnershipOnUniqueBufferKeepsBackpropID() {
+        var tensor = Tensor<Float, CPU>([1, 2, 3])
+        let id = tensor.backpropID
+        let address = tensor.bufferAddress
+        tensor.ensureOwnership()
+        
+        XCTAssertEqual(tensor.backpropID, id)
+        XCTAssertEqual(tensor.bufferAddress, address)
+    }
 }
 
 private extension Tensor where Device == CPU {
     var bufferAddress: UnsafeMutableRawPointer? {
         values.values.memory.baseAddress
     }
+
 }

--- a/Tests/DL4STests/OwnershipTests.swift
+++ b/Tests/DL4STests/OwnershipTests.swift
@@ -1,0 +1,177 @@
+//
+//  OwnershipTests.swift
+//  DL4S
+//
+//  Created by Palle Klewitz on 03.09.26.
+//  Copyright (c) 2026 - Palle Klewitz
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import XCTest
+@testable import DL4S
+
+
+class OwnershipTests: XCTestCase {
+    /// A tensor with the values of `source` and one backpropagation closure that observes the gradient flow to `source`.
+    ///
+    /// The closure receives the gradient of the probe and the accumulated gradient of `source`, and returns the new accumulated gradient.
+    func probeBackpropagation(_ source: Tensor<Float, CPU>, _ backpropagate: @escaping (Tensor<Float, CPU>, consuming Tensor<Float, CPU>?) -> Tensor<Float, CPU>) -> Tensor<Float, CPU> {
+        Tensor(
+            handle: source.handle,
+            shape: source.shape,
+            context: TensorContext(tag: "probe", sources: [source], backpropagateAccumulate: [backpropagate])
+        )
+    }
+    
+    func testMutableValuesCopiesSharedStorage() {
+        let original = Tensor<Float, CPU>([1, 2, 3])
+        var copy = original
+        CPU.Engine.fill(value: 0, result: copy.mutableValues.values, count: 3)
+
+        XCTAssertEqual(original, Tensor([1, 2, 3]))
+        XCTAssertEqual(copy, Tensor([0, 0, 0]))
+    }
+
+    func testMutableValuesCopiesViewStorage() {
+        let matrix = Tensor<Float, CPU>([[1, 2], [3, 4]])
+        var row = matrix[1]
+        CPU.Engine.fill(value: 0, result: row.mutableValues.values, count: 2)
+
+        XCTAssertEqual(matrix, Tensor([[1, 2], [3, 4]]))
+        XCTAssertEqual(row, Tensor([0, 0]))
+    }
+
+    func testAccumulationIntoSharedBufferLeavesOtherTensorUnchanged() {
+        let original = Tensor<Float, CPU>([[1, 2], [3, 4]])
+        var accumulator = original
+        accumulator.addingPermuted(Tensor([[10, 20], [30, 40]]), permutation: [1, 0])
+
+        XCTAssertEqual(original, Tensor([[1, 2], [3, 4]]))
+        XCTAssertEqual(accumulator, Tensor([[11, 32], [23, 44]]))
+    }
+
+    func testAccumulationIntoUniqueBufferIsInPlace() {
+        var accumulator = Tensor<Float, CPU>([[1, 2], [3, 4]])
+        let address = accumulator.bufferAddress
+        accumulator.addingPermuted(Tensor([[10, 20], [30, 40]]), permutation: [1, 0])
+
+        XCTAssertEqual(accumulator.bufferAddress, address)
+        XCTAssertEqual(accumulator, Tensor([[11, 32], [23, 44]]))
+    }
+
+    /// A residual connection makes the gradient of the sum and the gradient of the product share one buffer.
+    /// The product must not add into that buffer, or the gradient of the weight doubles.
+    func testResidualConnectionGradient() {
+        let a = Tensor<Float, CPU>([[1, 2], [3, 4]], requiresGradient: true)
+        let w = Tensor<Float, CPU>([[1, 0], [0, 1]], requiresGradient: true)
+        var sharedAddress: UnsafeMutableRawPointer?
+        // The probe is the residual path. It receives the gradient of the sum and passes it on to `a` unchanged.
+        let s = a.matrixMultiplied(with: w) + probeBackpropagation(a) { gradient, _ in
+            sharedAddress = gradient.bufferAddress
+            return gradient
+        }
+
+        let grads = s.gradients(of: [a, w])
+
+        XCTAssertEqual(grads[1], Tensor([[4, 4], [6, 6]]))
+        XCTAssertEqual(grads[0], Tensor([[2, 2], [2, 2]]))
+        XCTAssertNotNil(sharedAddress)
+        XCTAssertNotEqual(grads[0].bufferAddress, sharedAddress)
+    }
+
+    /// Only optimized builds accumulate without a copy. In unoptimized builds, a copy is accepted there.
+    func testWeightUsedTwiceAccumulatesGradientInPlace() {
+        let w = Tensor<Float, CPU>(uniformlyDistributedWithShape: [4, 3], requiresGradient: true)
+        let a = Tensor<Float, CPU>(uniformlyDistributedWithShape: [5, 4])
+        let b = Tensor<Float, CPU>(uniformlyDistributedWithShape: [5, 4])
+        let d = Tensor<Float, CPU>(uniformlyDistributedWithShape: [5, 4])
+        var addressAfterFirstProduct: UnsafeMutableRawPointer?
+        // Backpropagation visits the products in the order b, then the probe, then a. The probe records the
+        // accumulator that the first product created and hands it on without a contribution of its own.
+        let probed = probeBackpropagation(w) { _, accumulator in
+            addressAfterFirstProduct = accumulator?.bufferAddress
+            return accumulator!
+        }
+        let y = (a.matrixMultiplied(with: w) + d.matrixMultiplied(with: probed)) + b.matrixMultiplied(with: w)
+
+        let grad = y.gradients(of: [w])[0]
+
+        let expected = (a + b).transposed().matrixMultiplied(with: Tensor(repeating: 1, shape: [5, 3]))
+        XCTAssertLessThan(((grad - expected) * (grad - expected)).reduceSum().item, 1e-8)
+        XCTAssertNotNil(addressAfterFirstProduct)
+        #if !DEBUG
+        XCTAssertEqual(grad.bufferAddress, addressAfterFirstProduct)
+        #endif
+    }
+
+    func testTensorTransposedTwiceAccumulatesGradientInPlace() {
+        let a = Tensor<Float, CPU>(uniformlyDistributedWithShape: [4, 3], requiresGradient: true)
+        let b = Tensor<Float, CPU>(uniformlyDistributedWithShape: [3, 4])
+        let c = Tensor<Float, CPU>(uniformlyDistributedWithShape: [3, 4])
+        let d = Tensor<Float, CPU>(uniformlyDistributedWithShape: [3, 4])
+        var addressAfterFirstTranspose: UnsafeMutableRawPointer?
+        let probed = probeBackpropagation(a) { _, accumulator in
+            addressAfterFirstTranspose = accumulator?.bufferAddress
+            return accumulator!
+        }
+        let y = (a.transposed() * b + probed.transposed() * d) + a.transposed() * c
+
+        let grad = y.gradients(of: [a])[0]
+
+        let expected = (b + c).transposed()
+        XCTAssertLessThan(((grad - expected) * (grad - expected)).reduceSum().item, 1e-8)
+        XCTAssertNotNil(addressAfterFirstTranspose)
+        #if !DEBUG
+        XCTAssertEqual(grad.bufferAddress, addressAfterFirstTranspose)
+        #endif
+    }
+
+    func testTransposedMatrixProductGradients() {
+        let a = Tensor<Float, CPU>(uniformlyDistributedWithShape: [3, 4], requiresGradient: true)
+        let b = Tensor<Float, CPU>(uniformlyDistributedWithShape: [4, 5], requiresGradient: true)
+        let scale = Tensor<Float, CPU>(uniformlyDistributedWithShape: [3, 5])
+
+        for (transposeLhs, transposeRhs) in [(false, false), (true, false), (false, true), (true, true)] {
+            let lhs = transposeLhs ? a.transposed().detached() : a.detached()
+            let rhs = transposeRhs ? b.transposed().detached() : b.detached()
+            let lhsParameter = Tensor<Float, CPU>(lhs.elements, shape: lhs.shape, requiresGradient: true)
+            let rhsParameter = Tensor<Float, CPU>(rhs.elements, shape: rhs.shape, requiresGradient: true)
+
+            let fused = (lhsParameter.matrixMultiplied(with: rhsParameter, transposeSelf: transposeLhs, transposeOther: transposeRhs) * scale).reduceSum()
+            let fusedGrads = fused.gradients(of: [lhsParameter, rhsParameter])
+
+            let explicit = ((transposeLhs ? lhsParameter.transposed() : lhsParameter).matrixMultiplied(with: transposeRhs ? rhsParameter.transposed() : rhsParameter) * scale).reduceSum()
+            let explicitGrads = explicit.gradients(of: [lhsParameter, rhsParameter])
+
+            for (fusedGrad, explicitGrad) in zip(fusedGrads, explicitGrads) {
+                XCTAssertEqual(fusedGrad.shape, explicitGrad.shape)
+                XCTAssertLessThan(((fusedGrad - explicitGrad) * (fusedGrad - explicitGrad)).reduceSum().item, 1e-8, "transposeLhs: \(transposeLhs), transposeRhs: \(transposeRhs)")
+            }
+        }
+    }
+}
+
+private extension OwnershipTests {
+}
+
+private extension Tensor where Device == CPU {
+    var bufferAddress: UnsafeMutableRawPointer? {
+        values.values.memory.baseAddress
+    }
+}

--- a/Tests/DL4STests/RandomTests.swift
+++ b/Tests/DL4STests/RandomTests.swift
@@ -1,0 +1,133 @@
+//
+//  RandomTests.swift
+//  DL4STests
+//
+//  Created by Palle Klewitz on 03.09.26.
+//  Copyright (c) 2026 - Palle Klewitz
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import XCTest
+import DL4S
+
+/// Tests for seeded and unseeded random initialization.
+final class RandomTests: XCTestCase {
+    func testSameSeedProducesIdenticalTensors() {
+        var first = WyHash(seed: 42)
+        var second = WyHash(seed: 42)
+        
+        XCTAssertEqual(
+            Tensor<Float, CPU>(uniformlyDistributedWithShape: [64, 32], min: -1, max: 1, using: &first).elements,
+            Tensor<Float, CPU>(uniformlyDistributedWithShape: [64, 32], min: -1, max: 1, using: &second).elements
+        )
+        XCTAssertEqual(
+            Tensor<Double, CPU>(normalDistributedWithShape: [33], mean: 1, stdev: 2, using: &first).elements,
+            Tensor<Double, CPU>(normalDistributedWithShape: [33], mean: 1, stdev: 2, using: &second).elements
+        )
+        XCTAssertEqual(
+            Tensor<Float, CPU>(xavierNormalWithShape: [16, 8], using: &first).elements,
+            Tensor<Float, CPU>(xavierNormalWithShape: [16, 8], using: &second).elements
+        )
+        XCTAssertEqual(
+            Tensor<Float, CPU>(bernoulliDistributedWithShape: [256], probability: 0.3, using: &first).elements,
+            Tensor<Float, CPU>(bernoulliDistributedWithShape: [256], probability: 0.3, using: &second).elements
+        )
+    }
+    
+    func testSameSeedProducesIdenticalLayers() {
+        var first = WyHash(seed: 7)
+        var second = WyHash(seed: 7)
+        
+        let dense1 = Dense<Float, CPU>(inputSize: 16, outputSize: 8, using: &first)
+        let dense2 = Dense<Float, CPU>(inputSize: 16, outputSize: 8, using: &second)
+        XCTAssertEqual(dense1.weights.elements, dense2.weights.elements)
+        
+        let conv1 = Convolution2D<Float, CPU>(inputChannels: 3, outputChannels: 4, kernelSize: (3, 3), using: &first)
+        let conv2 = Convolution2D<Float, CPU>(inputChannels: 3, outputChannels: 4, kernelSize: (3, 3), using: &second)
+        XCTAssertEqual(conv1.filters.elements, conv2.filters.elements)
+        
+        let lstm1 = LSTM<Float, CPU>(inputSize: 5, hiddenSize: 6, using: &first)
+        let lstm2 = LSTM<Float, CPU>(inputSize: 5, hiddenSize: 6, using: &second)
+        XCTAssertEqual(lstm1.parameters.map(\.elements), lstm2.parameters.map(\.elements))
+        
+        let embedding1 = Embedding<Float, CPU>(inputFeatures: 10, outputSize: 4, using: &first)
+        let embedding2 = Embedding<Float, CPU>(inputFeatures: 10, outputSize: 4, using: &second)
+        XCTAssertEqual(embedding1.embeddingMatrix.elements, embedding2.embeddingMatrix.elements)
+    }
+    
+    func testSameSeedProducesIdenticalModels() {
+        var first = WyHash(seed: 11)
+        var second = WyHash(seed: 11)
+        
+        let block1 = ResidualBlock<Float, CPU>(inputShape: [4, 8, 8], outPlanes: 8, downsample: 2, using: &first)
+        let block2 = ResidualBlock<Float, CPU>(inputShape: [4, 8, 8], outPlanes: 8, downsample: 2, using: &second)
+        XCTAssertEqual(block1.parameters.map(\.elements), block2.parameters.map(\.elements))
+        
+        let transformer1 = Transformer<Float, CPU>(encoderLayers: 2, decoderLayers: 2, vocabSize: 32, hiddenDim: 16, heads: 2, keyDim: 8, valueDim: 8, forwardDim: 32, using: &first)
+        let transformer2 = Transformer<Float, CPU>(encoderLayers: 2, decoderLayers: 2, vocabSize: 32, hiddenDim: 16, heads: 2, keyDim: 8, valueDim: 8, forwardDim: 32, using: &second)
+        XCTAssertEqual(transformer1.parameters.map(\.elements), transformer2.parameters.map(\.elements))
+    }
+    
+    func testUnseededModelsDiffer() {
+        let transformer1 = Transformer<Float, CPU>(encoderLayers: 1, decoderLayers: 1, vocabSize: 32, hiddenDim: 16, heads: 2, keyDim: 8, valueDim: 8, forwardDim: 32)
+        let transformer2 = Transformer<Float, CPU>(encoderLayers: 1, decoderLayers: 1, vocabSize: 32, hiddenDim: 16, heads: 2, keyDim: 8, valueDim: 8, forwardDim: 32)
+        XCTAssertNotEqual(transformer1.parameters.map(\.elements), transformer2.parameters.map(\.elements))
+    }
+    
+    func testOneGeneratorAdvancesBetweenCalls() {
+        var generator = WyHash(seed: 1)
+        let first = Tensor<Float, CPU>(uniformlyDistributedWithShape: [128], using: &generator).elements
+        let second = Tensor<Float, CPU>(uniformlyDistributedWithShape: [128], using: &generator).elements
+        XCTAssertNotEqual(first, second)
+    }
+    
+    func testDifferentSeedsProduceDifferentTensors() {
+        var first = WyHash(seed: 1)
+        var second = WyHash(seed: 2)
+        XCTAssertNotEqual(
+            Tensor<Float, CPU>(uniformlyDistributedWithShape: [128], using: &first).elements,
+            Tensor<Float, CPU>(uniformlyDistributedWithShape: [128], using: &second).elements
+        )
+    }
+    
+    func testUnseededCallsProduceDifferentValues() {
+        let first = Tensor<Float, CPU>(uniformlyDistributedWithShape: [128])
+        let second = Tensor<Float, CPU>(uniformlyDistributedWithShape: [128])
+        XCTAssertNotEqual(first.elements, second.elements)
+        
+        let dense1 = Dense<Float, CPU>(inputSize: 16, outputSize: 8)
+        let dense2 = Dense<Float, CPU>(inputSize: 16, outputSize: 8)
+        XCTAssertNotEqual(dense1.weights.elements, dense2.weights.elements)
+    }
+    
+    func testNormalFillWritesEveryElementForOddCounts() {
+        var generator = WyHash(seed: 3)
+        let odd = Tensor<Float, CPU>(normalDistributedWithShape: [7], mean: 100, stdev: 0.001, using: &generator)
+        for value in odd.elements {
+            XCTAssertEqual(value, 100, accuracy: 0.1)
+        }
+    }
+    
+    func testBoundedDrawsAreNotConstant() {
+        var generator = WyHash(seed: 5)
+        let draws = (0 ..< 64).map { _ in generator.next(upperBound: UInt32(100)) }
+        XCTAssertGreaterThan(Set(draws).count, 1)
+        XCTAssertTrue(draws.allSatisfy { $0 < 100 })
+    }
+}

--- a/Tests/DL4STests/StackTests.swift
+++ b/Tests/DL4STests/StackTests.swift
@@ -1,0 +1,114 @@
+//
+//  StackTests.swift
+//  DL4STests
+//
+//  Created by Palle Klewitz on 03.09.26.
+//  Copyright (c) 2026 - Palle Klewitz
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import XCTest
+import DL4S
+
+final class StackTests: XCTestCase {
+    /// A stacked tensor that lives across many backward passes must not keep the gradients of earlier passes.
+    ///
+    /// Each unstack pass creates 8 MB of gradient tensors. One leak would grow the process by 800 MB.
+    func testLongLivedStackNodeDoesNotRetainGradients() throws {
+        let sources = (0 ..< 2).map { _ in
+            Tensor<Float, CPU>(uniformlyDistributedWithShape: [1000, 1000], requiresGradient: true)
+        }
+        let stacked = stack(sources)
+        let passCount = 100
+        let leakedBytesPerPass = sources.reduce(0) { $0 + $1.count * MemoryLayout<Float>.stride }
+        
+        func backwardPass() -> [Tensor<Float, CPU>] {
+            stacked.reduceSum().gradients(of: sources)
+        }
+        
+        // The first pass pays for allocator warm-up, so the baseline is measured after it.
+        _ = backwardPass()
+        guard let baseline = ProcessMemory.residentBytes() else {
+            throw XCTSkip("Resident memory is not available on this platform.")
+        }
+        
+        for _ in 0 ..< passCount {
+            let gradients = backwardPass()
+            XCTAssertEqual(gradients.count, sources.count)
+        }
+        
+        guard let final = ProcessMemory.residentBytes() else {
+            throw XCTSkip("Resident memory is not available on this platform.")
+        }
+        let growth = final - baseline
+        let tolerance = leakedBytesPerPass * passCount / 8
+        XCTAssertLessThan(
+            growth, tolerance,
+            "Resident memory grew by \(growth / 1_000_000) MB over \(passCount) backward passes. A leak of the gradient cache grows by \(leakedBytesPerPass * passCount / 1_000_000) MB."
+        )
+    }
+    
+    /// The gradient of a stacked tensor must reach every source, also when one tensor is stacked more than once.
+    func testStackGradientWithRepeatedSource() {
+        let a = Tensor<Float, CPU>([1, 2, 3], requiresGradient: true)
+        let b = Tensor<Float, CPU>([4, 5, 6], requiresGradient: true)
+        let weights = Tensor<Float, CPU>([1, 2, 3, 4, 5, 6, 7, 8, 9])
+        
+        let stacked = stack([a, b, a])
+        let loss = (stacked * weights).reduceSum()
+        let gradients = loss.gradients(of: [a, b])
+        
+        XCTAssertEqual(gradients[0], Tensor([8, 10, 12]))
+        XCTAssertEqual(gradients[1], Tensor([4, 5, 6]))
+    }
+    
+    /// A tensor that is stacked twice and also used outside the stack must receive the sum of all three contributions.
+    ///
+    /// The gradient from the other branch is already accumulated when the stack is visited, so this checks that
+    /// the accumulator is added once, not once per repeated source.
+    func testRepeatedSourceWithGradientFromOtherBranch() {
+        let a = Tensor<Float, CPU>([1, 2, 3], requiresGradient: true)
+        let stackWeights = Tensor<Float, CPU>([1, 2, 3, 4, 5, 6])
+        let otherWeights = Tensor<Float, CPU>([10, 20, 30])
+        let expected = Tensor<Float, CPU>([15, 27, 39])
+        
+        let stackBranch = (stack([a, a]) * stackWeights).reduceSum()
+        let otherBranch = (a * otherWeights).reduceSum()
+        
+        XCTAssertEqual((stackBranch + otherBranch).gradients(of: [a])[0], expected)
+        XCTAssertEqual((otherBranch + stackBranch).gradients(of: [a])[0], expected)
+        XCTAssertEqual((stackBranch + otherBranch).gradients(of: [a], retainBackwardsGraph: true)[0], expected)
+    }
+    
+    /// A retained backward graph must give the same gradient as a plain backward pass and must allow a second derivative.
+    func testStackGradientWithRetainedBackwardsGraph() {
+        let a = Tensor<Float, CPU>([1, 2, 3], requiresGradient: true)
+        let b = Tensor<Float, CPU>([4, 5, 6], requiresGradient: true)
+        
+        let stacked = stack([a, b])
+        let loss = (stacked * stacked * stacked).reduceSum()
+        let firstOrder = loss.gradients(of: [a, b], retainBackwardsGraph: true)
+        
+        XCTAssertEqual(firstOrder[0], Tensor([3, 12, 27]))
+        XCTAssertEqual(firstOrder[1], Tensor([48, 75, 108]))
+        
+        let secondOrder = firstOrder[0].reduceSum().gradients(of: [a])
+        XCTAssertEqual(secondOrder[0], Tensor([6, 12, 18]))
+    }
+}

--- a/Tests/DL4STests/TestUtil.swift
+++ b/Tests/DL4STests/TestUtil.swift
@@ -38,3 +38,41 @@ extension XCTestCase {
         )
     }
 }
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Reads memory statistics of the test process.
+enum ProcessMemory {
+    /// Resident set size of the process in bytes, or `nil` if the platform does not report it.
+    static func residentBytes() -> Int? {
+        #if canImport(Darwin)
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size)
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return nil
+        }
+        return Int(info.resident_size)
+        #elseif os(Linux)
+        // /proc/self/statm lists the total and resident size of the process in pages.
+        guard let statm = try? String(contentsOfFile: "/proc/self/statm", encoding: .utf8) else {
+            return nil
+        }
+        let fields = statm.split(separator: " ")
+        guard fields.count > 1, let residentPages = Int(fields[1]) else {
+            return nil
+        }
+        return residentPages * Int(sysconf(Int32(_SC_PAGESIZE)))
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Tests/DL4STests/TransformerMNISTTests.swift
+++ b/Tests/DL4STests/TransformerMNISTTests.swift
@@ -1,0 +1,104 @@
+//
+//  TransformerMNISTTests.swift
+//  DL4S
+//
+//  Created by Palle Klewitz on 03.09.26.
+//  Copyright (c) 2026 - Palle Klewitz
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import XCTest
+import DL4S
+
+
+/// Classifies an MNIST image as a sequence of 28 rows with a Transformer encoder.
+struct RowTransformerClassifier: LayerType, Codable {
+    typealias Inputs = Tensor<Float, CPU>
+    typealias Outputs = Tensor<Float, CPU>
+
+    var project: Dense<Float, CPU>
+    var positionalEncoding: PositionalEncoding<Float, CPU>
+    var encoder: TransformerEncoder<Float, CPU>
+    var classify: Dense<Float, CPU>
+
+    var parameters: [Tensor<Float, CPU>] {
+        Array([project.parameters, encoder.parameters, classify.parameters].joined())
+    }
+
+    var parameterPaths: [WritableKeyPath<Self, Tensor<Float, CPU>>] {
+        Array([
+            project.parameterPaths.map((\Self.project).appending(path:)),
+            encoder.parameterPaths.map((\Self.encoder).appending(path:)),
+            classify.parameterPaths.map((\Self.classify).appending(path:))
+        ].joined())
+    }
+
+    init<Generator: RandomNumberGenerator>(hiddenDim: Int, layers: Int, heads: Int, using generator: inout Generator) {
+        project = Dense(inputSize: 28, outputSize: hiddenDim, using: &generator)
+        positionalEncoding = PositionalEncoding(hiddenSize: hiddenDim)
+        encoder = TransformerEncoder(layerCount: layers, heads: heads, keyDim: hiddenDim / heads, valueDim: hiddenDim / heads, modelDim: hiddenDim, forwardDim: hiddenDim * 2, dropout: 0, using: &generator)
+        classify = Dense(inputSize: hiddenDim, outputSize: 10, using: &generator)
+    }
+
+    func callAsFunction(_ images: Tensor<Float, CPU>) -> Tensor<Float, CPU> {
+        let batchSize = images.shape[0]
+        let hiddenDim = positionalEncoding.hiddenSize
+        let rows = project(images.view(as: [batchSize * 28, 28])).view(as: [batchSize, 28, hiddenDim])
+        let encoded = encoder((input: rows + positionalEncoding(28), sequenceLengths: Array(repeating: 28, count: batchSize)))
+        return classify(encoded.reduceMean(along: [1])).logSoftmax()
+    }
+}
+
+class TransformerMNISTTests: XCTestCase {
+    func testRowTransformerLearnsMNIST() throws {
+        try skipUnlessLongTestsEnabled()
+
+        let ((images, labels), (testImages, testLabels)) = MNISTTests.loadMNIST(type: Float.self, device: CPU.self)
+        var generator = WyHash(seed: 42)
+        let model = RowTransformerClassifier(hiddenDim: 32, layers: 2, heads: 4, using: &generator)
+        var optimizer = Adam(model: model, learningRate: 0.001)
+        let batchSize = 64
+        let steps = 600
+        var bar = ProgressBar<Float>(totalUnitCount: steps, formatUserInfo: {"loss: \($0)"}, label: "training")
+
+        for _ in 1 ... steps {
+            let (input, target) = Random.minibatch(from: images, labels: labels, count: batchSize)
+            let prediction = optimizer.model(input.view(as: [batchSize, 28, 28]))
+            let loss = categoricalNegativeLogLikelihood(expected: target, actual: prediction)
+            optimizer.update(along: loss.gradients(of: optimizer.model.parameters))
+            bar.next(userInfo: loss.item)
+        }
+        bar.complete()
+
+        let evaluationCount = 2000
+        let prediction = optimizer.model(testImages[0 ..< evaluationCount].view(as: [evaluationCount, 28, 28])).elements
+        let expected = testLabels[0 ..< evaluationCount].elements
+        var correct = 0
+        for i in 0 ..< evaluationCount {
+            let scores = prediction[(i * 10) ..< (i * 10 + 10)]
+            let predictedClass = scores.indices.max { scores[$0] < scores[$1] }! - i * 10
+            if Int32(predictedClass) == expected[i] {
+                correct += 1
+            }
+        }
+        let accuracy = Float(correct) / Float(evaluationCount)
+        print("test accuracy: \(accuracy)")
+        XCTAssertGreaterThan(accuracy, 0.9)
+    }
+}

--- a/Tests/DL4STests/TransformerTests.swift
+++ b/Tests/DL4STests/TransformerTests.swift
@@ -65,7 +65,17 @@ class TransformerTests: XCTestCase {
             }
         }
         bar.complete()
-        
+
         XCTAssertLessThanOrEqual(lastLoss, 0.1)
+    }
+
+    func testLayerNormNormalizesEachSequenceElement() {
+        let norm = LayerNorm<Float, CPU>(inputSize: [4])
+        let x = Tensor<Float, CPU>(uniformlyDistributedWithShape: [2, 3, 4], min: -10, max: 10)
+
+        let perSequenceElement = norm(x)
+        let flat = norm(x.view(as: [6, 4])).view(as: [2, 3, 4])
+
+        XCTAssertLessThan(((perSequenceElement - flat) * (perSequenceElement - flat)).reduceSum().item, 1e-8)
     }
 }

--- a/Tests/DL4STests/UtilTests.swift
+++ b/Tests/DL4STests/UtilTests.swift
@@ -27,8 +27,6 @@ import XCTest
 @testable import DL4S
 
 class UtilTests: XCTestCase {
-    @ThreadLocal private var x = 42
-    
     func testFileReader() {
         let packageManifestURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()  // DL4STests
@@ -40,20 +38,5 @@ class UtilTests: XCTestCase {
         for line in f {
             print("### \(line)")
         }
-    }
-    
-    func testThreadLocal() {
-        XCTAssertEqual(self.x, 42)
-        x = 1337
-        // Using sema instead of sync block, because sync block is executed on main thread.
-        let sema = DispatchSemaphore(value: 0)
-        DispatchQueue.global().async {
-            XCTAssertEqual(self.x, 42)
-            self.x = 314
-            XCTAssertEqual(self.x, 314)
-            sema.signal()
-        }
-        sema.wait()
-        XCTAssertEqual(self.x, 1337)
     }
 }


### PR DESCRIPTION
- Adds concurrency test suite
- RNG now no longer riddled with race conditions
- async free is removed - performs worse
- introduce mutable buffer types
- improve backprop through ownership consumption
- fixes bugs in gradient accumulation of subscripts
- fixes layernorm behavior
- optimize away caching of stack operation backwards pass
- adds thread sanitizer job.